### PR TITLE
feat: add mistake deck mode and stats

### DIFF
--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -14,7 +14,6 @@
       </view>
       <button
         class="btn btn-secondary deck-toggle-btn"
-        :class="{ active: deckSource === 'mistake' }"
         @click="toggleDeckSource"
       >{{ deckSourceLabel }}</button>
     </view>
@@ -300,7 +299,22 @@ function loadSession() {
   } catch (_) { return false }
 }
 
-const remainingCards = computed(() => (deck.value || []).length)
+const remainingCards = computed(() => {
+  if (deckSource.value === 'mistake') {
+    const uid = selectedUserId.value
+    if (!uid) return 0
+    const pool = getActivePool(uid) || []
+    if (!Array.isArray(pool) || pool.length === 0) return 0
+    const used = mistakeRunUsed.value instanceof Set ? mistakeRunUsed.value : new Set()
+    let remainingHands = 0
+    for (const item of pool) {
+      if (!item || !item.key) continue
+      if (!used.has(item.key)) remainingHands += 1
+    }
+    return remainingHands * 4
+  }
+  return Array.isArray(deck.value) ? deck.value.length : 0
+})
 const winRate = computed(() => {
   const t = successCount.value + failCount.value
   return t ? Math.round(100 * successCount.value / t) : 0
@@ -1290,8 +1304,15 @@ function onSessionOver() {
 .mode-switch { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; flex:1; }
 .mode-switch-btn { width:100%; }
 .mode-switch-btn.active { background:#145751; color:#fff; }
-.deck-toggle-btn { width:auto; padding:28rpx 36rpx; white-space:nowrap; font-weight:700; border:2rpx solid #0f766e; color:#0f766e; background:#ecfdf5; }
-.deck-toggle-btn.active { background:#145751; color:#fff; border-color:#145751; }
+.deck-toggle-btn {
+  width:auto;
+  padding:28rpx 36rpx;
+  white-space:nowrap;
+  font-weight:700;
+  border:2rpx solid #145751;
+  color:#fff;
+  background:#145751;
+}
 
 .btn { border:none; border-radius:16rpx; padding:28rpx 0; font-size:32rpx; line-height:1; box-shadow:0 8rpx 20rpx rgba(15,23,42,.06); width:100%; display:flex; align-items:center; justify-content:center; box-sizing:border-box; }
 .btn-operator { background:#fff; color:#2563eb; border:2rpx solid #e5e7eb; font-size:64rpx;font-weight: bold;}

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -7,17 +7,16 @@
       <button class="btn btn-secondary" style="padding:16rpx 20rpx; width:auto;" @click="goLogin">切换用户</button>
     </view>
 
-    <view class="deck-source-bar">
-      <text class="deck-source-label">题库：</text>
-      <view class="deck-source-seg">
-        <button class="btn btn-secondary deck-source-btn" :class="{ active: deckSource === 'normal' }" @click="switchDeckSource('normal')">常规</button>
-        <button class="btn btn-secondary deck-source-btn" :class="{ active: deckSource === 'mistake' }" @click="switchDeckSource('mistake')">错题</button>
+    <view class="mode-bar">
+      <view class="mode-switch">
+        <button class="btn btn-secondary mode-switch-btn" :class="{ active: mode === 'basic' }" @click="mode = 'basic'">Basic 模式</button>
+        <button class="btn btn-secondary mode-switch-btn" :class="{ active: mode === 'pro' }" @click="mode = 'pro'">Pro 模式</button>
       </view>
-    </view>
-
-    <view class="mode-switch">
-      <button class="btn btn-secondary mode-switch-btn" :class="{ active: mode === 'basic' }" @click="mode = 'basic'">Basic 模式</button>
-      <button class="btn btn-secondary mode-switch-btn" :class="{ active: mode === 'pro' }" @click="mode = 'pro'">Pro 模式</button>
+      <button
+        class="btn btn-secondary deck-toggle-btn"
+        :class="{ active: deckSource === 'mistake' }"
+        @click="toggleDeckSource"
+      >{{ deckSourceLabel }}</button>
     </view>
 
     <!-- 本局统计：紧凑表格（1行表头 + 1行数据） -->
@@ -206,6 +205,7 @@ const exprZoneHeight = ref(200)
 const currentUser = ref(null)
 const deck = ref([])
 const deckSource = ref('normal')
+const deckSourceLabel = computed(() => deckSource.value === 'mistake' ? '题库：错题' : '题库：整副')
 const mistakeRunUsed = ref(new Set())
 const mistakeRunStamp = ref(0)
 const currentHandSource = ref('normal')
@@ -674,6 +674,11 @@ function restartMistakeRun() {
   resetMistakeRun(Date.now())
   try { saveSession() } catch (_) {}
   nextTick(() => { if (deckSource.value === 'mistake') nextHand() })
+}
+
+function toggleDeckSource() {
+  const next = deckSource.value === 'mistake' ? 'normal' : 'mistake'
+  switchDeckSource(next)
 }
 
 function switchDeckSource(target) {
@@ -1280,15 +1285,13 @@ function onSessionOver() {
 .ops-row-2 { display:grid; grid-template-columns:1fr 1fr; gap:18rpx; align-items:stretch; }
 .ops-left { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; }
 .pair-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; }
+.mode-bar { display:flex; align-items:stretch; gap:18rpx; margin: 8rpx 0 16rpx; }
 .mode-btn { width: 100%; white-space: nowrap; }
-.mode-switch { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; margin: 8rpx 0 16rpx; }
+.mode-switch { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; flex:1; }
 .mode-switch-btn { width:100%; }
 .mode-switch-btn.active { background:#145751; color:#fff; }
-.deck-source-bar { display:flex; align-items:center; gap:12rpx; margin-top: 8rpx; }
-.deck-source-label { color:#6b7280; font-size:26rpx; font-weight:600; }
-.deck-source-seg { display:grid; grid-template-columns:repeat(2,1fr); gap:12rpx; flex:1; }
-.deck-source-btn { width:100%; }
-.deck-source-btn.active { background:#145751; color:#fff; }
+.deck-toggle-btn { width:auto; padding:28rpx 36rpx; white-space:nowrap; font-weight:700; border:2rpx solid #0f766e; color:#0f766e; background:#ecfdf5; }
+.deck-toggle-btn.active { background:#145751; color:#fff; border-color:#145751; }
 
 .btn { border:none; border-radius:16rpx; padding:28rpx 0; font-size:32rpx; line-height:1; box-shadow:0 8rpx 20rpx rgba(15,23,42,.06); width:100%; display:flex; align-items:center; justify-content:center; box-sizing:border-box; }
 .btn-operator { background:#fff; color:#2563eb; border:2rpx solid #e5e7eb; font-size:64rpx;font-weight: bold;}

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -602,25 +602,21 @@ async function drawFromMistakePool() {
   const pool = getActivePool(uid) || []
   if (!Array.isArray(pool) || pool.length === 0) {
     await new Promise(resolve => {
+      const fallback = () => {
+        switchDeckSource('normal')
+        resolve(null)
+      }
       try {
         uni.showModal({
           title: '提示',
-          content: '错题本为空，先切回常规或去统计看看～',
-          cancelText: '切回常规',
-          confirmText: '去统计',
-          success: (res) => {
-            if (res && res.confirm) {
-              goStats()
-            } else {
-              switchDeckSource('normal')
-            }
-            resolve(null)
-          },
-          fail: () => resolve(null),
+          content: '无错题，切换到整副牌。',
+          confirmText: 'OK',
+          showCancel: false,
+          success: () => fallback(),
+          fail: () => fallback(),
         })
       } catch (_) {
-        switchDeckSource('normal')
-        resolve(null)
+        fallback()
       }
     })
     return null
@@ -629,25 +625,31 @@ async function drawFromMistakePool() {
   const available = pool.filter(item => item && item.key && !used.has(item.key))
   if (!available.length) {
     await new Promise(resolve => {
+      const fallback = () => {
+        restartMistakeRun()
+        resolve(null)
+      }
       try {
-        uni.showModal({
-          title: '提示',
-          content: '本轮错题已练完。要重开一轮还是去统计？',
-          cancelText: '重开一轮',
-          confirmText: '去统计',
+        uni.showActionSheet({
+          title: '本轮错题已出完',
+          itemList: ['重新出题', '切换整副', '去统计'],
           success: (res) => {
-            if (res && res.confirm) {
+            const idx = typeof res?.tapIndex === 'number' ? res.tapIndex : -1
+            if (idx === 0) {
+              restartMistakeRun()
+            } else if (idx === 1) {
+              switchDeckSource('normal')
+            } else if (idx === 2) {
               goStats()
             } else {
               restartMistakeRun()
             }
             resolve(null)
           },
-          fail: () => resolve(null),
+          fail: () => fallback(),
         })
       } catch (_) {
-        restartMistakeRun()
-        resolve(null)
+        fallback()
       }
     })
     return null

--- a/utils/mistakes.js
+++ b/utils/mistakes.js
@@ -1,0 +1,175 @@
+const KEY_PREFIX = 'mistakes:'
+
+function createEmptyBook() {
+  return { active: {}, ledger: {} }
+}
+
+function toInt(val) {
+  const num = Number(val)
+  if (!Number.isFinite(num)) return 0
+  return Math.max(0, Math.floor(num))
+}
+
+function sanitizeNums(nums, fallbackKey) {
+  if (Array.isArray(nums) && nums.length) {
+    return nums.map(n => Number.isFinite(+n) ? +n : 0).sort((a, b) => a - b)
+  }
+  if (typeof fallbackKey === 'string' && fallbackKey) {
+    return fallbackKey.split(',').map(n => Number.isFinite(+n) ? +n : 0).sort((a, b) => a - b)
+  }
+  return []
+}
+
+function sanitizeItem(key, item) {
+  const now = Date.now()
+  const base = item && typeof item === 'object' ? item : {}
+  const nums = sanitizeNums(base.nums, key)
+  const attempts = toInt(base.attempts)
+  const wrong = toInt(base.wrong)
+  const correct = toInt(base.correct)
+  const total = attempts || (wrong + correct)
+  const streak = toInt(base.streakCorrect)
+  const lastSeen = Number.isFinite(+base.lastSeenTs) ? +base.lastSeenTs : 0
+  const created = Number.isFinite(+base.createdTs) ? +base.createdTs : now
+  const lastResult = base.lastResult === 'correct' || base.lastResult === 'wrong' ? base.lastResult : null
+  return {
+    key: typeof base.key === 'string' && base.key ? base.key : key,
+    nums,
+    attempts: total,
+    wrong,
+    correct,
+    lastSeenTs: lastSeen,
+    lastResult,
+    streakCorrect: streak,
+    createdTs: created,
+  }
+}
+
+export function normalizeKey(nums = []) {
+  if (!Array.isArray(nums) || nums.length === 0) return ''
+  return nums
+    .map(n => Number.isFinite(+n) ? +n : 0)
+    .sort((a, b) => a - b)
+    .join(',')
+}
+
+export function loadMistakeBook(userId) {
+  if (!userId) return createEmptyBook()
+  try {
+    const raw = uni.getStorageSync(KEY_PREFIX + userId)
+    if (!raw) return createEmptyBook()
+    const data = typeof raw === 'string' ? JSON.parse(raw) : raw
+    if (!data || typeof data !== 'object') return createEmptyBook()
+    const book = createEmptyBook()
+    const active = data.active && typeof data.active === 'object' ? data.active : {}
+    const ledger = data.ledger && typeof data.ledger === 'object' ? data.ledger : {}
+    for (const key of Object.keys(active)) {
+      book.active[key] = sanitizeItem(key, active[key])
+    }
+    for (const key of Object.keys(ledger)) {
+      book.ledger[key] = sanitizeItem(key, ledger[key])
+    }
+    return book
+  } catch (_) {
+    return createEmptyBook()
+  }
+}
+
+export function saveMistakeBook(userId, book) {
+  if (!userId) return
+  const data = book && typeof book === 'object' ? book : createEmptyBook()
+  try {
+    uni.setStorageSync(KEY_PREFIX + userId, JSON.stringify({
+      active: data.active || {},
+      ledger: data.ledger || {},
+    }))
+  } catch (_) {
+    /* noop */
+  }
+}
+
+export function getActivePool(userId) {
+  const book = loadMistakeBook(userId)
+  return Object.values(book.active || {})
+}
+
+export function recordRoundResult({ userId, nums, success }) {
+  if (!userId || !Array.isArray(nums) || nums.length === 0) return
+  const sortedNums = nums.map(n => Number.isFinite(+n) ? +n : 0).sort((a, b) => a - b)
+  const key = normalizeKey(sortedNums)
+  if (!key) return
+  const now = Date.now()
+  const book = loadMistakeBook(userId)
+  const ledger = book.ledger || {}
+  const active = book.active || {}
+
+  const existingLedger = ledger[key] ? sanitizeItem(key, ledger[key]) : sanitizeItem(key, { key, nums: sortedNums, createdTs: now })
+  const updated = { ...existingLedger }
+  updated.nums = sortedNums.slice()
+  updated.attempts = toInt(updated.attempts) + 1
+  updated.createdTs = Number.isFinite(+updated.createdTs) ? +updated.createdTs : now
+  updated.lastSeenTs = now
+  updated.lastResult = success ? 'correct' : 'wrong'
+  if (success) {
+    updated.correct = toInt(updated.correct) + 1
+    updated.streakCorrect = toInt(updated.streakCorrect) + 1
+  } else {
+    updated.wrong = toInt(updated.wrong) + 1
+    updated.streakCorrect = 0
+  }
+  ledger[key] = updated
+
+  const isActive = !!active[key]
+  if (!success) {
+    const activeItem = isActive ? sanitizeItem(key, active[key]) : sanitizeItem(key, { key, nums: sortedNums, createdTs: now })
+    activeItem.nums = sortedNums.slice()
+    activeItem.attempts = updated.attempts
+    activeItem.wrong = updated.wrong
+    activeItem.correct = updated.correct
+    activeItem.lastSeenTs = now
+    activeItem.lastResult = 'wrong'
+    activeItem.streakCorrect = 0
+    active[key] = activeItem
+  } else if (success && updated.streakCorrect >= 5) {
+    if (isActive) delete active[key]
+  } else if (isActive) {
+    const activeItem = sanitizeItem(key, active[key])
+    activeItem.nums = sortedNums.slice()
+    activeItem.attempts = updated.attempts
+    activeItem.wrong = updated.wrong
+    activeItem.correct = updated.correct
+    activeItem.lastSeenTs = now
+    activeItem.lastResult = 'correct'
+    activeItem.streakCorrect = updated.streakCorrect
+    active[key] = activeItem
+  }
+
+  book.ledger = ledger
+  book.active = active
+  saveMistakeBook(userId, book)
+}
+
+export function getSummary(userId) {
+  const book = loadMistakeBook(userId)
+  const ledger = book.ledger || {}
+  let totalWrong = 0
+  for (const key of Object.keys(ledger)) {
+    totalWrong += toInt(ledger[key]?.wrong)
+  }
+  const totalActive = Object.keys(book.active || {}).length
+  return { totalWrongCount: totalWrong, totalActiveCount: totalActive }
+}
+
+export function syncMistakeBook() {
+  // 预留接口，未来可用于云端同步
+}
+
+export default {
+  normalizeKey,
+  loadMistakeBook,
+  saveMistakeBook,
+  getActivePool,
+  recordRoundResult,
+  getSummary,
+  syncMistakeBook,
+}


### PR DESCRIPTION
## Summary
- add persistent mistake book utilities for tracking wrong hands
- allow switching between normal and mistake decks with per-run controls on the game page
- surface mistake summaries and sortable tables on the stats page

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ce0ef0e3648323898397f0b2b17dff