### PR TITLE
Implement avatar persistence, edge exit gestures, and new UI interactions

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -1,6 +1,9 @@
 <script>
+import { ensureUserAvatars } from './utils/avatar.js'
+
 export default {
   onLaunch() {
+    try { ensureUserAvatars && ensureUserAvatars().catch(() => {}) } catch (_) {}
     try {
       // 仅 App 端支持预加载，H5 忽略
       // #ifdef APP-PLUS

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -185,7 +185,7 @@
       v-if="hintState.visible"
       class="floating-hint-layer"
       :class="{ interactive: hintState.interactive }"
-      @tap="hintState.interactive ? hideHint() : null"
+      @tap="hideHint"
     >
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>
@@ -275,7 +275,7 @@ const basicErrorMessages = {
 
 function showBasicError(code) {
   const msg = basicErrorMessages[code] || '操作无效，请重试'
-  showHint(msg, 1600)
+  showHint(msg, { interactive: true })
 }
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitGamePage() })
 
@@ -467,7 +467,7 @@ function resetBasicStateFromCards() {
 function handleBasicOperator(op) {
   if (mode.value !== 'basic' || handSettled.value) return
   if (basicSelection.value.first === null) {
-    showHint('请先选择一个数字', 1500)
+    showHint('请先选择一个数字', { interactive: true })
     return
   }
   if (basicSelection.value.operator === op) {

--- a/pages/stats/index.vue
+++ b/pages/stats/index.vue
@@ -5,6 +5,7 @@
     @touchstart="edgeHandlers.handleTouchStart"
     @touchmove="edgeHandlers.handleTouchMove"
     @touchend="edgeHandlers.handleTouchEnd"
+    @touchcancel="edgeHandlers.handleTouchCancel"
   >
     <view class="section">
       <view class="row" style="justify-content:space-between; align-items:center; gap:12rpx; flex-wrap:wrap;">
@@ -446,6 +447,7 @@ import { loadMistakeBook, getSummary as getMistakeSummary } from '../../utils/mi
 import { useFloatingHint } from '../../utils/hints.js'
 import { useEdgeExit } from '../../utils/edge-exit.js'
 import { consumeAvatarRestoreNotice } from '../../utils/avatar.js'
+import { exitApp } from '../../utils/navigation.js'
 import {
   computeOverviewRows,
   computeNearMisses,
@@ -1040,38 +1042,27 @@ const overviewRowsSorted = computed(() => {
 })
 
 function exitStatsPage() {
-  const fallback = () => {
-    try {
-      if (typeof uni.switchTab === 'function') {
-        uni.switchTab({ url: '/pages/index/index' })
-        return
-      }
-    } catch (_) {}
-    try {
-      if (typeof uni.reLaunch === 'function') {
-        uni.reLaunch({ url: '/pages/index/index' })
-        return
-      }
-    } catch (_) {}
-    try {
-      if (typeof plus !== 'undefined' && plus.runtime && typeof plus.runtime.quit === 'function') {
-        plus.runtime.quit()
-      }
-    } catch (_) {}
-  }
-  try {
-    if (typeof uni.navigateBack === 'function') {
-      uni.navigateBack({ delta: 1, fail: () => fallback() })
-    } else {
-      fallback()
-    }
-  } catch (_) {
-    fallback()
-  }
+  exitApp({
+    fallback: () => {
+      try {
+        if (typeof uni.switchTab === 'function') {
+          uni.switchTab({ url: '/pages/index/index' })
+          return
+        }
+      } catch (_) {}
+      try {
+        if (typeof uni.reLaunch === 'function') {
+          uni.reLaunch({ url: '/pages/index/index' })
+          return
+        }
+      } catch (_) {}
+    },
+  })
 }
 </script>
 
 <style scoped>
+.page{ min-height:100vh; box-sizing:border-box; position:relative; }
 .section{ background:#fff; border:2rpx solid #e5e7eb; border-radius:16rpx; padding:16rpx; box-shadow:0 6rpx 16rpx rgba(15,23,42,.06) }
 .section.title{ background:none; font-size:36rpx; font-weight:800; margin-bottom:12rpx }
 .title{ font-size:32rpx; font-weight:800 }

--- a/pages/stats/index.vue
+++ b/pages/stats/index.vue
@@ -428,7 +428,7 @@
       v-if="hintState.visible"
       class="floating-hint-layer"
       :class="{ interactive: hintState.interactive }"
-      @tap="hintState.interactive ? hideHint() : null"
+      @tap="hideHint"
     >
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -26,7 +26,7 @@
       v-if="hintState.visible"
       class="floating-hint-layer"
       :class="{ interactive: hintState.interactive }"
-      @tap="hintState.interactive ? hideHint() : null"
+      @tap="hideHint"
     >
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -2,7 +2,8 @@
   <view class="page" style="padding:24rpx; display:flex; flex-direction:column; gap:16rpx;"
         @touchstart="edgeHandlers.handleTouchStart"
         @touchmove="edgeHandlers.handleTouchMove"
-        @touchend="edgeHandlers.handleTouchEnd">
+        @touchend="edgeHandlers.handleTouchEnd"
+        @touchcancel="edgeHandlers.handleTouchCancel">
     <view class="row" style="gap:12rpx; align-items:center;">
       <input v-model="newName" placeholder="新用户名称" class="input" />
       <button class="btn btn-primary" @tap="create">添加</button>
@@ -42,6 +43,7 @@ import { ensureInit, getUsers, addUser, renameUser, removeUser as rmUser, switch
 import { useFloatingHint } from '../../utils/hints.js'
 import { useEdgeExit } from '../../utils/edge-exit.js'
 import { saveAvatarForUser, removeAvatarForUser, consumeAvatarRestoreNotice } from '../../utils/avatar.js'
+import { exitApp } from '../../utils/navigation.js'
 
 const users = ref({ list: [], currentId: '' })
 const newName = ref('')
@@ -135,34 +137,22 @@ function avatarText(name){
 }
 
 function exitPage(){
-  const fallback = () => {
-    try {
-      if (typeof uni.switchTab === 'function') {
-        uni.switchTab({ url: '/pages/index/index' })
-        return
-      }
-    } catch (_) {}
-    try {
-      if (typeof uni.reLaunch === 'function') {
-        uni.reLaunch({ url: '/pages/index/index' })
-        return
-      }
-    } catch (_) {}
-    try {
-      if (typeof plus !== 'undefined' && plus.runtime && typeof plus.runtime.quit === 'function') {
-        plus.runtime.quit()
-      }
-    } catch (_) {}
-  }
-  try {
-    if (typeof uni.navigateBack === 'function') {
-      uni.navigateBack({ delta: 1, fail: () => fallback() })
-    } else {
-      fallback()
+  exitApp({
+    fallback: () => {
+      try {
+        if (typeof uni.switchTab === 'function') {
+          uni.switchTab({ url: '/pages/index/index' })
+          return
+        }
+      } catch (_) {}
+      try {
+        if (typeof uni.reLaunch === 'function') {
+          uni.reLaunch({ url: '/pages/index/index' })
+          return
+        }
+      } catch (_) {}
     }
-  } catch (_) {
-    fallback()
-  }
+  })
 }
 </script>
 
@@ -179,6 +169,7 @@ function exitPage(){
 .mini{ padding:8rpx 12rpx; border-radius:10rpx; background:#eef2f7; font-size:24rpx }
 .mini.danger{ background:#fee2e2; color:#b91c1c }
 .btn-primary{ background:#1677ff; color:#fff; border:none; padding:18rpx 24rpx; border-radius:12rpx }
+.page{ min-height:100vh; box-sizing:border-box; position:relative; }
 .floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
 .floating-hint-layer.interactive{ pointer-events:auto }
 .floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }

--- a/utils/avatar.js
+++ b/utils/avatar.js
@@ -1,0 +1,399 @@
+import { getUsers, setUsers, setUserAvatar } from './store.js'
+import { writeAvatarMeta, clearAvatarMeta } from './prefs.js'
+
+export const MAX_AVATAR_SIZE = 2 * 1024 * 1024
+export const AVATAR_NOTICE_KEY = 'tf24_avatar_restore_notice'
+
+function getFS() {
+  try {
+    if (typeof uni !== 'undefined' && typeof uni.getFileSystemManager === 'function') {
+      return uni.getFileSystemManager()
+    }
+  } catch (_) {}
+  return null
+}
+
+function isPlusAvailable() {
+  try { return typeof plus !== 'undefined' && plus && plus.io } catch (_) { return false }
+}
+
+function extractExt(path, fallback = '.png') {
+  if (!path) return fallback
+  const m = /\.(jpg|jpeg|png|webp)$/i.exec(path)
+  return m ? `.${m[1].toLowerCase()}` : fallback
+}
+
+function composeAvatarDir() {
+  try {
+    if (isPlusAvailable()) return '_doc/profile'
+    if (typeof uni !== 'undefined' && uni.env && uni.env.USER_DATA_PATH) {
+      return `${uni.env.USER_DATA_PATH}/profile`
+    }
+    if (typeof wx !== 'undefined' && wx.env && wx.env.USER_DATA_PATH) {
+      return `${wx.env.USER_DATA_PATH}/profile`
+    }
+  } catch (_) {}
+  return ''
+}
+
+async function ensureDir(dirPath) {
+  if (!dirPath) return false
+  const fs = getFS()
+  if (fs && typeof fs.access === 'function' && typeof fs.mkdir === 'function') {
+    return await new Promise(resolve => {
+      fs.access({ path: dirPath, success: () => resolve(true), fail: () => {
+        fs.mkdir({ dirPath, recursive: true, success: () => resolve(true), fail: () => resolve(false) })
+      } })
+    })
+  }
+  if (fs && typeof fs.mkdirSync === 'function') {
+    try { fs.mkdirSync(dirPath, true); return true } catch (_) { return false }
+  }
+  if (isPlusAvailable()) {
+    return await new Promise(resolve => {
+      try {
+        plus.io.resolveLocalFileSystemURL('_doc/', root => {
+          const rel = dirPath.replace(/^_doc\/?/, '')
+          if (!rel) { resolve(true); return }
+          const segments = rel.split('/').filter(Boolean)
+          let current = root
+          function next(i) {
+            if (i >= segments.length) { resolve(true); return }
+            const name = segments[i]
+            try {
+              current.getDirectory(name, { create: true }, dir => { current = dir; next(i + 1) }, () => resolve(false))
+            } catch (_) {
+              resolve(false)
+            }
+          }
+          next(0)
+        }, () => resolve(false))
+      } catch (_) { resolve(false) }
+    })
+  }
+  return false
+}
+
+async function fileExists(path) {
+  if (!path) return false
+  const fs = getFS()
+  if (fs && typeof fs.access === 'function') {
+    return await new Promise(resolve => {
+      fs.access({ path, success: () => resolve(true), fail: () => resolve(false) })
+    })
+  }
+  if (fs && typeof fs.accessSync === 'function') {
+    try { fs.accessSync(path); return true } catch (_) { return false }
+  }
+  if (fs && typeof fs.stat === 'function') {
+    return await new Promise(resolve => {
+      fs.stat({ path, success: () => resolve(true), fail: () => resolve(false) })
+    })
+  }
+  if (isPlusAvailable()) {
+    return await new Promise(resolve => {
+      try { plus.io.resolveLocalFileSystemURL(path, () => resolve(true), () => resolve(false)) } catch (_) { resolve(false) }
+    })
+  }
+  return false
+}
+
+async function removeFile(path) {
+  if (!path) return false
+  const fs = getFS()
+  if (fs && typeof fs.unlink === 'function') {
+    return await new Promise(resolve => {
+      fs.unlink({ filePath: path, success: () => resolve(true), fail: () => resolve(false) })
+    })
+  }
+  if (fs && typeof fs.unlinkSync === 'function') {
+    try { fs.unlinkSync(path); return true } catch (_) { return false }
+  }
+  if (isPlusAvailable()) {
+    return await new Promise(resolve => {
+      try {
+        plus.io.resolveLocalFileSystemURL(path, entry => {
+          entry.remove(() => resolve(true), () => resolve(false))
+        }, () => resolve(false))
+      } catch (_) { resolve(false) }
+    })
+  }
+  return false
+}
+
+async function copyFile(src, dest) {
+  if (!src || !dest) return false
+  const fs = getFS()
+  if (fs && typeof fs.copyFile === 'function') {
+    return await new Promise(resolve => {
+      fs.copyFile({ srcPath: src, destPath: dest, success: () => resolve(true), fail: () => resolve(false) })
+    })
+  }
+  if (fs && typeof fs.copyFileSync === 'function') {
+    try { fs.copyFileSync(src, dest); return true } catch (_) {}
+  }
+  if (fs && typeof fs.readFile === 'function' && typeof fs.writeFile === 'function') {
+    const data = await new Promise(resolve => {
+      fs.readFile({ filePath: src, encoding: 'binary', success: res => resolve(res.data), fail: () => resolve(null) })
+    })
+    if (data == null) return false
+    return await new Promise(resolve => {
+      fs.writeFile({ filePath: dest, data, encoding: 'binary', success: () => resolve(true), fail: () => resolve(false) })
+    })
+  }
+  if (isPlusAvailable()) {
+    return await new Promise(resolve => {
+      try {
+        plus.io.resolveLocalFileSystemURL(src, entry => {
+          const dir = dest.substring(0, dest.lastIndexOf('/')) || '_doc'
+          const name = dest.substring(dest.lastIndexOf('/') + 1)
+          ensureDir(dir).then(ok => {
+            if (!ok) { resolve(false); return }
+            try {
+              plus.io.resolveLocalFileSystemURL(dir, dirEntry => {
+                const attemptCopy = () => {
+                  entry.copyTo(dirEntry, name, () => resolve(true), () => resolve(false))
+                }
+                dirEntry.getFile(name, { create: false }, fileEntry => {
+                  fileEntry.remove(() => attemptCopy(), () => attemptCopy())
+                }, () => attemptCopy())
+              }, () => resolve(false))
+            } catch (_) { resolve(false) }
+          })
+        }, () => resolve(false))
+      } catch (_) { resolve(false) }
+    })
+  }
+  return false
+}
+
+async function getFileInfo(path) {
+  if (!path) return null
+  const fs = getFS()
+  if (fs && typeof fs.stat === 'function') {
+    return await new Promise(resolve => {
+      fs.stat({ path, success: res => resolve({ size: res.size || 0, lastModified: res.mtime || res.lastModifiedTime || Date.now() }), fail: () => resolve(null) })
+    })
+  }
+  if (fs && typeof fs.getFileInfo === 'function') {
+    return await new Promise(resolve => {
+      fs.getFileInfo({ filePath: path, success: res => resolve({ size: res.size || 0, lastModified: res.lastModifiedTime || Date.now() }), fail: () => resolve(null) })
+    })
+  }
+  if (isPlusAvailable()) {
+    return await new Promise(resolve => {
+      try {
+        plus.io.resolveLocalFileSystemURL(path, entry => {
+          entry.getMetadata(meta => {
+            const size = meta.size || 0
+            const lastModified = meta.modificationTime instanceof Date ? meta.modificationTime.getTime() : Date.now()
+            resolve({ size, lastModified })
+          }, () => resolve(null))
+        }, () => resolve(null))
+      } catch (_) { resolve(null) }
+    })
+  }
+  return null
+}
+
+async function saveFileFallback(tempPath) {
+  if (!tempPath) return ''
+  if (typeof uni !== 'undefined' && typeof uni.saveFile === 'function') {
+    return await new Promise(resolve => {
+      uni.saveFile({ tempFilePath: tempPath, success: res => resolve(res && res.savedFilePath ? res.savedFilePath : ''), fail: () => resolve('') })
+    })
+  }
+  return ''
+}
+
+async function compressImage(path, quality) {
+  if (!path) return { ok: false, path, size: 0 }
+  if (typeof uni === 'undefined' || typeof uni.compressImage !== 'function') {
+    return { ok: false, path, size: 0 }
+  }
+  return await new Promise(resolve => {
+    uni.compressImage({
+      src: path,
+      quality,
+      success: res => {
+        const newPath = res && res.tempFilePath ? res.tempFilePath : path
+        getFileInfo(newPath).then(info => {
+          resolve({ ok: true, path: newPath, size: info ? info.size || 0 : 0 })
+        })
+      },
+      fail: () => resolve({ ok: false, path, size: 0 })
+    })
+  })
+}
+
+function withinAvatarDir(path) {
+  if (!path) return false
+  const dir = composeAvatarDir()
+  if (!dir) return false
+  return path.startsWith(dir)
+}
+
+async function copyIntoAvatarDir(userId, sourcePath, options = {}) {
+  const dir = composeAvatarDir()
+  if (!dir) return { ok: false, path: '', lastModified: 0 }
+  const ensured = await ensureDir(dir)
+  if (!ensured) return { ok: false, path: '', lastModified: 0 }
+  const ext = options.ext || extractExt(sourcePath)
+  const dest = `${dir}/avatar_${userId}${ext}`
+  const copied = await copyFile(sourcePath, dest)
+  if (!copied) return { ok: false, path: '', lastModified: 0 }
+  const info = await getFileInfo(dest)
+  return { ok: true, path: dest, lastModified: info ? info.lastModified || Date.now() : Date.now() }
+}
+
+async function prepareSource(tempPath, sizeHint) {
+  if (!tempPath) return { path: '', size: 0 }
+  let size = Number.isFinite(sizeHint) ? sizeHint : 0
+  if (!size) {
+    const info = await getFileInfo(tempPath)
+    size = info ? info.size || 0 : 0
+  }
+  if (size > MAX_AVATAR_SIZE) {
+    let currentPath = tempPath
+    for (const quality of [80, 60, 45]) {
+      const res = await compressImage(currentPath, quality)
+      if (res.ok && res.size > 0) {
+        currentPath = res.path
+        size = res.size
+        if (size <= MAX_AVATAR_SIZE) {
+          return { path: currentPath, size }
+        }
+      }
+    }
+    return { path: currentPath, size }
+  }
+  return { path: tempPath, size }
+}
+
+function legacyCandidates(user) {
+  const list = []
+  if (!user) return list
+  const id = user.id
+  const avatar = user.avatar
+  if (avatar) list.push(avatar)
+  const legacyBase = composeAvatarDir().replace(/profile$/, '') || ''
+  if (legacyBase) {
+    list.push(`${legacyBase}Documents/app/avatar_${id}.png`)
+    list.push(`${legacyBase}Documents/app/avatar.png`)
+  }
+  list.push(`_doc/avatar_${id}.png`)
+  list.push(`_doc/avatar.png`)
+  return Array.from(new Set(list.filter(Boolean)))
+}
+
+export async function saveAvatarForUser(userId, tempPath, options = {}) {
+  if (!userId || !tempPath) return { ok: false, error: 'invalid', path: '', lastModified: 0 }
+  const users = getUsers()
+  const user = (users.list || []).find(u => u && u.id === userId)
+  if (!user) return { ok: false, error: 'not_found', path: '', lastModified: 0 }
+  const prepared = await prepareSource(tempPath, options.size)
+  if (!prepared.path) return { ok: false, error: 'invalid', path: '', lastModified: 0 }
+  let workingPath = prepared.path
+  let stored = { ok: false, path: '', lastModified: 0 }
+  if (prepared.size && prepared.size <= MAX_AVATAR_SIZE) {
+    stored = await copyIntoAvatarDir(userId, workingPath, { ext: extractExt(tempPath) })
+  } else {
+    stored = await copyIntoAvatarDir(userId, workingPath, { ext: extractExt(tempPath) })
+  }
+  if (!stored.ok || !stored.path) {
+    const fallback = await saveFileFallback(workingPath)
+    if (fallback) {
+      const info = await getFileInfo(fallback)
+      stored = { ok: true, path: fallback, lastModified: info ? info.lastModified || Date.now() : Date.now() }
+    }
+  }
+  if (!stored.ok || !stored.path) {
+    return { ok: false, error: 'fs_failed', path: '', lastModified: 0 }
+  }
+  const prev = user.avatar || ''
+  if (prev && prev !== stored.path) {
+    await removeFile(prev)
+  }
+  setUserAvatar(userId, stored.path, stored.lastModified)
+  writeAvatarMeta(userId, { uri: stored.path, lastModified: stored.lastModified })
+  return stored
+}
+
+export async function removeAvatarForUser(userId) {
+  if (!userId) return { ok: false }
+  const users = getUsers()
+  const user = (users.list || []).find(u => u && u.id === userId)
+  if (!user) return { ok: false }
+  const prev = user.avatar || ''
+  if (prev) { await removeFile(prev) }
+  setUserAvatar(userId, '', 0)
+  clearAvatarMeta(userId)
+  return { ok: true }
+}
+
+export async function ensureUserAvatars() {
+  const users = getUsers()
+  const list = Array.isArray(users.list) ? users.list : []
+  let changed = false
+  let fallbackCount = 0
+  for (const user of list) {
+    if (!user || !user.id) continue
+    if (!user.avatar) {
+      if (user.avatarUpdatedAt) { user.avatarUpdatedAt = 0; changed = true }
+      clearAvatarMeta(user.id)
+      continue
+    }
+    const exists = await fileExists(user.avatar)
+    if (exists) {
+      if (!withinAvatarDir(user.avatar)) {
+        const res = await copyIntoAvatarDir(user.id, user.avatar, { ext: extractExt(user.avatar) })
+        if (res.ok && res.path) {
+          const prev = user.avatar
+          user.avatar = res.path
+          user.avatarUpdatedAt = res.lastModified
+          changed = true
+          writeAvatarMeta(user.id, { uri: res.path, lastModified: res.lastModified })
+          if (prev && prev !== res.path) { await removeFile(prev) }
+        }
+      }
+      continue
+    }
+    let restored = false
+    for (const cand of legacyCandidates(user)) {
+      if (!cand) continue
+      const ok = await fileExists(cand)
+      if (!ok) continue
+      const res = await copyIntoAvatarDir(user.id, cand, { ext: extractExt(cand) })
+      if (res.ok && res.path) {
+        user.avatar = res.path
+        user.avatarUpdatedAt = res.lastModified
+        changed = true
+        writeAvatarMeta(user.id, { uri: res.path, lastModified: res.lastModified })
+        restored = true
+        break
+      }
+    }
+    if (!restored) {
+      user.avatar = ''
+      user.avatarUpdatedAt = 0
+      clearAvatarMeta(user.id)
+      fallbackCount += 1
+      changed = true
+    }
+  }
+  if (changed) setUsers(users)
+  if (fallbackCount > 0) {
+    try { uni.setStorageSync(AVATAR_NOTICE_KEY, Date.now()) } catch (_) {}
+  }
+}
+
+export function consumeAvatarRestoreNotice() {
+  try {
+    const ts = uni.getStorageSync(AVATAR_NOTICE_KEY)
+    if (!ts) return false
+    uni.removeStorageSync(AVATAR_NOTICE_KEY)
+    return true
+  } catch (_) {
+    return false
+  }
+}

--- a/utils/edge-exit.js
+++ b/utils/edge-exit.js
@@ -70,7 +70,7 @@ export function useEdgeExit(options = {}) {
 
     if (typeof showHint === 'function') {
       try { uni.$emit && uni.$emit('edge_exit_hint_shown') } catch (_) {}
-      showHint('再次从屏幕边缘滑动即可退出', 2000)
+      showHint('再次从屏幕边缘滑动即可退出', { duration: 2000, interactive: false })
     }
   }
 

--- a/utils/edge-exit.js
+++ b/utils/edge-exit.js
@@ -1,0 +1,99 @@
+import { onUnmounted } from 'vue'
+
+function getTouchPoint(e) {
+  const t = (e && e.touches && e.touches[0]) || (e && e.changedTouches && e.changedTouches[0]) || {}
+  const x = t.clientX ?? t.pageX ?? t.x ?? 0
+  const y = t.clientY ?? t.pageY ?? t.y ?? 0
+  return { x, y }
+}
+
+export function useEdgeExit(options = {}) {
+  const { showHint, onExit, confirmWindow = 2000, edgeDp = 16 } = options || {}
+  const sys = (uni.getSystemInfoSync && uni.getSystemInfoSync()) ? uni.getSystemInfoSync() : {}
+  const width = sys.windowWidth || 0
+  const pixelRatio = sys.pixelRatio || 1
+  const edgePx = Math.max(12, Math.round(edgeDp * (Number.isFinite(pixelRatio) && pixelRatio > 0 ? pixelRatio : 1)))
+
+  const state = {
+    tracking: false,
+    startX: 0,
+    startY: 0,
+    lastDX: 0,
+    lastDY: 0,
+    isEdge: false,
+  }
+
+  let confirmTimer = null
+  let confirmDeadline = 0
+
+  function resetTracking() {
+    state.tracking = false
+    state.isEdge = false
+    state.lastDX = 0
+    state.lastDY = 0
+  }
+
+  function handleTouchStart(e) {
+    const { x, y } = getTouchPoint(e)
+    state.tracking = true
+    state.startX = x
+    state.startY = y
+    state.lastDX = 0
+    state.lastDY = 0
+    state.isEdge = (x <= edgePx) || (width && x >= width - edgePx)
+  }
+
+  function handleTouchMove(e) {
+    if (!state.tracking) return
+    const { x, y } = getTouchPoint(e)
+    state.lastDX = x - state.startX
+    state.lastDY = y - state.startY
+  }
+
+  function attemptExit() {
+    const now = Date.now()
+    if (confirmTimer && now <= confirmDeadline) {
+      clearTimeout(confirmTimer)
+      confirmTimer = null
+      confirmDeadline = 0
+      try { onExit && onExit() } catch (_) {}
+      try { uni.$emit && uni.$emit('edge_exit_confirm_exit') } catch (_) {}
+      return
+    }
+
+    confirmDeadline = now + confirmWindow
+    if (confirmTimer) { clearTimeout(confirmTimer); confirmTimer = null }
+    confirmTimer = setTimeout(() => {
+      confirmTimer = null
+      confirmDeadline = 0
+    }, confirmWindow)
+
+    if (typeof showHint === 'function') {
+      try { uni.$emit && uni.$emit('edge_exit_hint_shown') } catch (_) {}
+      showHint('再次从屏幕边缘滑动即可退出', 2000)
+    }
+  }
+
+  function handleTouchEnd() {
+    if (!state.tracking) return
+    const dx = state.lastDX
+    const dy = state.lastDY
+    const edge = state.isEdge
+    resetTracking()
+    if (!edge) return
+    const absX = Math.abs(dx)
+    const absY = Math.abs(dy)
+    if (absX < 60 || absX <= absY * 1.2) return
+    attemptExit()
+  }
+
+  onUnmounted(() => {
+    if (confirmTimer) { clearTimeout(confirmTimer); confirmTimer = null }
+  })
+
+  return {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  }
+}

--- a/utils/edge-exit.js
+++ b/utils/edge-exit.js
@@ -87,6 +87,10 @@ export function useEdgeExit(options = {}) {
     attemptExit()
   }
 
+  function handleTouchCancel() {
+    resetTracking()
+  }
+
   onUnmounted(() => {
     if (confirmTimer) { clearTimeout(confirmTimer); confirmTimer = null }
   })
@@ -95,5 +99,6 @@ export function useEdgeExit(options = {}) {
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
+    handleTouchCancel,
   }
 }

--- a/utils/hints.js
+++ b/utils/hints.js
@@ -1,0 +1,54 @@
+import { reactive, onUnmounted } from 'vue'
+import { getLastHintTimestamp, setLastHintTimestamp } from './prefs.js'
+
+export function useFloatingHint() {
+  const state = reactive({
+    visible: false,
+    text: '',
+    interactive: false,
+    id: 0,
+  })
+  let timer = null
+  let lastStamp = 0
+
+  try {
+    const persisted = getLastHintTimestamp()
+    if (Number.isFinite(persisted)) lastStamp = persisted
+  } catch (_) { lastStamp = 0 }
+
+  function hideHint() {
+    state.visible = false
+    state.text = ''
+    state.interactive = false
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function showHint(text, duration = 1800, options = {}) {
+    const now = Date.now()
+    if (now - lastStamp < 300) {
+      return
+    }
+    lastStamp = now
+    try { setLastHintTimestamp(now) } catch (_) {}
+
+    state.text = typeof text === 'string' ? text : ''
+    state.visible = !!state.text
+    state.interactive = !!options.interactive
+    state.id = (state.id || 0) + 1
+
+    if (timer) { clearTimeout(timer); timer = null }
+    const autoDuration = Number.isFinite(options.duration) ? options.duration : duration
+    if (!state.interactive && autoDuration > 0) {
+      timer = setTimeout(() => { hideHint() }, autoDuration)
+    }
+  }
+
+  onUnmounted(() => {
+    if (timer) { clearTimeout(timer); timer = null }
+  })
+
+  return { hintState: state, showHint, hideHint }
+}

--- a/utils/navigation.js
+++ b/utils/navigation.js
@@ -1,0 +1,82 @@
+export function exitApp(options = {}) {
+  const { fallback } = options || {}
+
+  const attempts = [
+    () => {
+      try {
+        if (typeof plus !== 'undefined' && plus && plus.runtime && typeof plus.runtime.quit === 'function') {
+          plus.runtime.quit()
+          return true
+        }
+      } catch (_) {}
+      return false
+    },
+    () => {
+      try {
+        if (typeof uni !== 'undefined' && uni && typeof uni.exit === 'function') {
+          uni.exit()
+          return true
+        }
+      } catch (_) {}
+      return false
+    },
+    () => {
+      try {
+        if (typeof wx !== 'undefined' && wx && typeof wx.exitMiniProgram === 'function') {
+          wx.exitMiniProgram()
+          return true
+        }
+      } catch (_) {}
+      return false
+    },
+  ]
+
+  for (const attempt of attempts) {
+    if (attempt()) {
+      return true
+    }
+  }
+
+  let navigated = false
+  try {
+    if (typeof uni !== 'undefined' && uni && typeof uni.navigateBack === 'function') {
+      uni.navigateBack({
+        delta: 1,
+        success: () => {
+          navigated = true
+        },
+        fail: () => {
+          if (!navigated && typeof fallback === 'function') {
+            fallback()
+          }
+        },
+        complete: () => {
+          if (!navigated && typeof fallback === 'function') {
+            fallback()
+          }
+        },
+      })
+      return false
+    }
+  } catch (_) {}
+
+  if (typeof fallback === 'function') {
+    fallback()
+    return false
+  }
+
+  try {
+    if (typeof window !== 'undefined') {
+      if (window.history && window.history.length > 1) {
+        window.history.back()
+        return false
+      }
+      if (typeof window.close === 'function') {
+        window.close()
+        return false
+      }
+    }
+  } catch (_) {}
+
+  return false
+}

--- a/utils/prefs.js
+++ b/utils/prefs.js
@@ -1,0 +1,100 @@
+const PREFS_KEY = 'tf24_prefs_v1'
+
+function readPrefs() {
+  try {
+    const raw = uni.getStorageSync(PREFS_KEY)
+    if (!raw) return {}
+    if (typeof raw === 'string') {
+      try { return JSON.parse(raw) || {} } catch (_) { return {} }
+    }
+    return raw && typeof raw === 'object' ? raw : {}
+  } catch (_) {
+    return {}
+  }
+}
+
+function writePrefs(data) {
+  try {
+    uni.setStorageSync(PREFS_KEY, JSON.stringify(data || {}))
+  } catch (_) { /* noop */ }
+}
+
+function normalizePrefs(prefs) {
+  const p = prefs && typeof prefs === 'object' ? { ...prefs } : {}
+  if (!p || typeof p !== 'object') return {}
+  if (p.lastMode !== 'pro' && p.lastMode !== 'basic') {
+    p.lastMode = 'basic'
+  }
+  if (!Number.isFinite(p.lastHintTs)) {
+    p.lastHintTs = 0
+  }
+  if (!p.avatarMeta || typeof p.avatarMeta !== 'object') {
+    p.avatarMeta = {}
+  }
+  return p
+}
+
+export function getPrefs() {
+  return normalizePrefs(readPrefs())
+}
+
+function updatePrefs(updater) {
+  const cur = getPrefs()
+  const next = typeof updater === 'function' ? updater(cur) : { ...cur, ...(updater || {}) }
+  writePrefs(next)
+  return next
+}
+
+export function getLastMode() {
+  const prefs = getPrefs()
+  return prefs.lastMode === 'pro' ? 'pro' : 'basic'
+}
+
+export function setLastMode(mode) {
+  updatePrefs(p => ({ ...p, lastMode: mode === 'pro' ? 'pro' : 'basic' }))
+}
+
+export function getLastHintTimestamp() {
+  const prefs = getPrefs()
+  return Number.isFinite(prefs.lastHintTs) ? prefs.lastHintTs : 0
+}
+
+export function setLastHintTimestamp(ts) {
+  const stamp = Number.isFinite(ts) ? Math.max(0, Math.floor(ts)) : Date.now()
+  updatePrefs(p => ({ ...p, lastHintTs: stamp }))
+}
+
+export function clearLastHintTimestamp() {
+  updatePrefs(p => ({ ...p, lastHintTs: 0 }))
+}
+
+export function readAvatarMeta(userId) {
+  if (!userId) return null
+  const prefs = getPrefs()
+  const meta = prefs.avatarMeta || {}
+  const data = meta[userId]
+  if (!data || typeof data !== 'object') return null
+  const uri = typeof data.uri === 'string' ? data.uri : ''
+  const lastModified = Number.isFinite(data.lastModified) ? data.lastModified : 0
+  return { uri, lastModified }
+}
+
+export function writeAvatarMeta(userId, meta) {
+  if (!userId) return
+  updatePrefs(p => {
+    const avatarMeta = { ...(p.avatarMeta || {}) }
+    if (!meta || !meta.uri) {
+      delete avatarMeta[userId]
+    } else {
+      avatarMeta[userId] = {
+        uri: meta.uri,
+        lastModified: Number.isFinite(meta.lastModified) ? meta.lastModified : Date.now(),
+      }
+    }
+    return { ...p, avatarMeta }
+  })
+}
+
+export function clearAvatarMeta(userId) {
+  writeAvatarMeta(userId, null)
+}


### PR DESCRIPTION
## Summary
- persist user avatars across upgrades by saving to a dedicated profile directory with compression, migration, and metadata updates
- add reusable floating hint overlay, edge exit confirmation gestures, timer popover with redeal, and a single mode toggle with persisted preference
- surface avatar restoration notices across pages and update user/stat screens to use the new hint and gesture utilities

## Testing
- Not run (uni-app project without automated tests in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf7af7d5bc8323a026d1e9c44c5675