### PR TITLE
feat: refresh global theme and background

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -21,6 +21,26 @@ export default {
 <style>
 /* 全局样式可放在 uni.scss 中 */
 page {
-  background-color: #f8f8f8;
+  min-height: 100%;
+  background-color: var(--bg-canvas);
+  background-image: var(--bg-canvas-gradient), url('@/static/bg-pattern.svg');
+  background-repeat: no-repeat, repeat;
+  background-size: cover, 520rpx 520rpx;
+  background-position: center, 0 0;
+  animation: ambientShift 36s ease-in-out infinite;
+  color: var(--text-body);
+  transition: background-color 0.3s ease;
+}
+
+@keyframes ambientShift {
+  0% {
+    background-position: center, 0 0;
+  }
+  50% {
+    background-position: center, 220rpx 180rpx;
+  }
+  100% {
+    background-position: center, 0 0;
+  }
 }
 </style>

--- a/static/bg-pattern.svg
+++ b/static/bg-pattern.svg
@@ -1,0 +1,19 @@
+<svg width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bubble" cx="20%" cy="20%" r="60%">
+      <stop offset="0%" stop-color="#3a7afe" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#3a7afe" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="bubble2" cx="80%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#20c997" stop-opacity="0.22" />
+      <stop offset="100%" stop-color="#20c997" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="bubble3" cx="60%" cy="80%" r="65%">
+      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.16" />
+      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#bubble)" />
+  <rect width="400" height="400" fill="url(#bubble2)" />
+  <rect width="400" height="400" fill="url(#bubble3)" />
+</svg>

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,25 +1,159 @@
 /* 通用卡片与标题 */
-.card { background:#fff; border:2rpx solid #e5e7eb; border-radius:16rpx; box-shadow:0 6rpx 16rpx rgba(15,23,42,.06) }
-.section { padding:16rpx }
-.title { font-size:32rpx; font-weight:800; color:#0f172a }
+.card {
+  position: relative;
+  background: var(--surface-base);
+  background-image: var(--gradient-card);
+  border: 1rpx solid var(--border-soft);
+  border-radius: 24rpx;
+  box-shadow: var(--shadow-soft);
+  padding: 24rpx;
+  color: var(--text-body);
+}
 
-/* 通用按钮 */
-.btn-primary { background:#145751; color:#fff; border:none }
-.btn-ghost { background:transparent; color:#145751; border:2rpx solid #145751 }
+.section { padding: 16rpx; }
+.title {
+  font-size: 32rpx;
+  font-weight: 800;
+  color: var(--text-strong);
+  letter-spacing: 0.6rpx;
+}
+.sub-title {
+  font-size: 26rpx;
+  color: var(--text-muted);
+}
+
+/* 通用按钮（覆盖不同颜色主题） */
+.btn-primary {
+  background-image: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-strong) 100%);
+  color: var(--text-inverse);
+  border: none;
+  box-shadow: 0 10rpx 24rpx rgba(58, 122, 254, 0.28);
+}
+
+.btn-secondary {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(229, 240, 255, 0.9));
+  color: var(--color-primary-strong);
+}
+
+.btn-ghost {
+  color: var(--text-body);
+  border-color: rgba(15, 23, 42, 0.16);
+}
+
+.btn-success {
+  background-image: linear-gradient(135deg, var(--color-secondary) 0%, var(--color-secondary-strong) 100%);
+  color: var(--text-inverse);
+  box-shadow: 0 10rpx 24rpx rgba(32, 201, 151, 0.26);
+}
 
 /* 表格型网格容器（统计页通用） */
-.grid-table { border-radius:12rpx; overflow:hidden; border:1rpx solid #e5e7eb }
-.grid-table .thead, .grid-table .tbody { display:grid; align-items:center; grid-gap:6rpx; min-height:44rpx }
-.grid-table .thead { color:#6b7280; font-weight:700; padding:8rpx 12rpx; background:#f8fafc; font-size:24rpx }
-.grid-table .tr { padding:10rpx 12rpx; border-top:1rpx solid #f1f5f9; font-size:26rpx }
-.grid-table .td, .grid-table .th { text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; line-height:1.4 }
-.ok { color:#16a34a; font-weight:700 }
-.fail { color:#dc2626; font-weight:700 }
+.grid-table {
+  border-radius: 20rpx;
+  overflow: hidden;
+  border: 1rpx solid rgba(148, 163, 184, 0.22);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 10rpx 28rpx rgba(15, 23, 42, 0.08);
+}
+.grid-table .thead,
+.grid-table .tbody {
+  display: grid;
+  align-items: center;
+  grid-gap: 6rpx;
+  min-height: 44rpx;
+}
+.grid-table .thead {
+  color: var(--text-muted);
+  font-weight: 700;
+  padding: 12rpx 20rpx;
+  background: linear-gradient(135deg, rgba(58, 122, 254, 0.08), rgba(32, 201, 151, 0.08));
+  font-size: 24rpx;
+}
+.grid-table .tr {
+  padding: 14rpx 20rpx;
+  border-top: 1rpx solid rgba(226, 232, 240, 0.9);
+  font-size: 26rpx;
+  color: var(--text-body);
+  background: rgba(255, 255, 255, 0.86);
+}
+.grid-table .tr:nth-child(even) {
+  background: rgba(248, 250, 252, 0.9);
+}
+.grid-table .td,
+.grid-table .th {
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+}
+.ok { color: var(--color-secondary-strong); font-weight: 700; }
+.fail { color: #ef4444; font-weight: 700; }
 
 /* 迷你图形：条形与微火柴的基础样式 */
-.bar-track { position:relative; height:14rpx; background:#e5e7eb; border-radius:9999rpx; overflow:hidden }
-.bar-fill { position:absolute; left:0; top:0; bottom:0; background:#16a34a; border-radius:9999rpx }
-.spark { display:flex; align-items:flex-end; gap:2rpx }
-.spark .seg { width:6rpx; background:#94a3b8; border-radius:2rpx }
-.spark .seg.ok { background:#16a34a }
+.bar-track {
+  position: relative;
+  height: 14rpx;
+  background: rgba(148, 163, 184, 0.32);
+  border-radius: 9999rpx;
+  overflow: hidden;
+}
+.bar-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--color-secondary);
+  border-radius: 9999rpx;
+}
+.spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 2rpx;
+}
+.spark .seg {
+  width: 6rpx;
+  background: rgba(148, 163, 184, 0.74);
+  border-radius: 2rpx;
+}
+.spark .seg.ok {
+  background: var(--color-secondary);
+}
 
+/* 通用渐变、描边与蒙层工具类 */
+.bg-ambient {
+  background: var(--gradient-ambient);
+}
+.bg-canvas {
+  background: var(--bg-canvas-gradient);
+}
+.bg-glass {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.72));
+  border: 1rpx solid rgba(255, 255, 255, 0.4);
+}
+.glow-outline-primary {
+  box-shadow: 0 0 0 3rpx rgba(58, 122, 254, 0.55), 0 18rpx 36rpx rgba(58, 122, 254, 0.22);
+  border-radius: 28rpx;
+}
+.glow-outline-secondary {
+  box-shadow: 0 0 0 3rpx rgba(32, 201, 151, 0.5), 0 18rpx 36rpx rgba(32, 201, 151, 0.18);
+  border-radius: 28rpx;
+}
+.mask-soft {
+  background-color: rgba(15, 23, 42, 0.24);
+}
+.mask-strong {
+  background-color: rgba(15, 23, 42, 0.55);
+}
+.mask-light {
+  background-color: rgba(255, 255, 255, 0.4);
+}
+.surface-blur {
+  background-color: rgba(255, 255, 255, 0.82);
+  border: 1rpx solid rgba(255, 255, 255, 0.3);
+}
+
+/* 阴影与间距工具 */
+.shadow-soft { box-shadow: var(--shadow-soft); }
+.shadow-strong { box-shadow: var(--shadow-strong); }
+.rounded-xl { border-radius: 28rpx; }
+.rounded-2xl { border-radius: 36rpx; }

--- a/uni.scss
+++ b/uni.scss
@@ -1,10 +1,96 @@
 /* 自定义主题变量或全局样式（使用原生 CSS 变量，避免预处理器依赖） */
-:root { --primary: #3a7afe; --text: #333; }
+:root {
+  --color-primary: #3a7afe;
+  --color-primary-strong: #2a5ede;
+  --color-secondary: #20c997;
+  --color-secondary-strong: #17a37a;
+  --color-accent: #f59e0b;
+  --text-strong: #0f172a;
+  --text-body: #1f2937;
+  --text-muted: #6b7280;
+  --text-subtle: #94a3b8;
+  --text-inverse: #ffffff;
+  --surface-base: rgba(255, 255, 255, 0.9);
+  --surface-muted: rgba(248, 250, 252, 0.82);
+  --border-soft: rgba(15, 23, 42, 0.08);
+  --shadow-soft: 0 12rpx 36rpx rgba(15, 23, 42, 0.08);
+  --shadow-strong: 0 18rpx 48rpx rgba(15, 23, 42, 0.12);
+  --gradient-ambient: linear-gradient(135deg, rgba(58, 122, 254, 0.18), rgba(32, 201, 151, 0.18));
+  --gradient-card: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.65));
+  --bg-canvas: #edf1ff;
+  --bg-canvas-gradient: linear-gradient(140deg, #eff4ff 0%, #f9fffb 45%, #eef2ff 100%);
+  --btn-radius: 999rpx;
+}
 
 /* 简易按钮样式（兼容 H5/APP/小程序） */
-.btn { padding: 20rpx 28rpx; border-radius: 12rpx; font-size: 28rpx; border:2rpx solid transparent; }
-.btn-primary { background-color: var(--primary); color: #fff; border-color: var(--primary); }
-.btn-secondary { background-color: #fff; color: var(--primary); border: 2rpx solid var(--primary); }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12rpx;
+  padding: 22rpx 40rpx;
+  border-radius: var(--btn-radius);
+  font-size: 28rpx;
+  font-weight: 600;
+  border: 2rpx solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.25s ease, color 0.25s ease;
+  box-shadow: 0 8rpx 18rpx rgba(15, 23, 42, 0.12);
+}
+
+.btn-primary {
+  background-image: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-strong) 100%);
+  color: var(--text-inverse);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.btn-secondary {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.72));
+  color: var(--color-primary-strong);
+  border: 2rpx solid rgba(58, 122, 254, 0.32);
+  box-shadow: inset 0 0 0 2rpx rgba(255, 255, 255, 0.6);
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: var(--text-body);
+  border: 2rpx solid rgba(15, 23, 42, 0.18);
+  box-shadow: none;
+}
+
+@media (hover: hover) {
+  .btn:hover {
+    transform: translateY(-4rpx);
+    box-shadow: 0 12rpx 28rpx rgba(15, 23, 42, 0.18);
+  }
+  .btn-primary:hover {
+    background-image: linear-gradient(135deg, var(--color-primary-strong) 0%, var(--color-primary) 100%);
+  }
+  .btn-secondary:hover {
+    border-color: rgba(58, 122, 254, 0.48);
+    color: var(--color-primary);
+  }
+  .btn-ghost:hover {
+    background-color: rgba(148, 163, 184, 0.12);
+  }
+}
+
+.btn:active {
+  transform: translateY(2rpx);
+  box-shadow: 0 4rpx 12rpx rgba(15, 23, 42, 0.14);
+}
+
+.btn-primary:active {
+  background-image: linear-gradient(135deg, var(--color-primary-strong) 0%, #1f4fd1 100%);
+}
+
+.btn-secondary:active {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(233, 243, 255, 0.88));
+}
+
+.btn-ghost:active {
+  background-color: rgba(148, 163, 184, 0.2);
+}
+
 .row { display: flex; flex-direction: row; align-items: center; }
 .col { display: flex; flex-direction: column; }
 .space-between { justify-content: space-between; }


### PR DESCRIPTION
## Summary
- expand root-level theme tokens with gradients, text tiers, and shared shadows
- restyle button, card, and table components with capsule controls plus gradient/glow utilities
- add animated background texture at the app shell using a new static pattern asset

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfaec186a4832383b43e06f8eeee5e