### PR TITLE
feat: refresh tab bar visuals and button styles

### DIFF
--- a/components/CustomTabBar.vue
+++ b/components/CustomTabBar.vue
@@ -1,16 +1,20 @@
 <template>
   <view class="ctb" :style="wrapStyle">
-    <button class="ctb-item" :class="{ active: isActive('stats') }" @click="go('/pages/stats/index')">
-      <text class="icon" :class="{ active: isActive('stats') }">📊</text>
-      <text class="label" :class="{ active: isActive('stats') }">统计</text>
-    </button>
-    <button class="ctb-item" :class="{ active: isActive('index') }" @click="go('/pages/index/index')">
-      <text class="icon" :class="{ active: isActive('index') }">🎮</text>
-      <text class="label" :class="{ active: isActive('index') }">程序</text>
-    </button>
-    <button class="ctb-item" :class="{ active: isActive('user') }" @click="go('/pages/user/index')">
-      <text class="icon" :class="{ active: isActive('user') }">👤</text>
-      <text class="label" :class="{ active: isActive('user') }">用户</text>
+    <button
+      v-for="tab in tabs"
+      :key="tab.key"
+      class="ctb-item"
+      :class="{ active: isActive(tab.key) }"
+      @click="go(tab.url)"
+    >
+      <view class="ctb-item-body">
+        <view class="icon-shell" :class="{ active: isActive(tab.key) }">
+          <image class="icon-img" mode="aspectFit" :src="tab.icon" />
+          <view v-if="tab.badge" class="badge">{{ tab.badge }}</view>
+          <view v-else-if="tab.dot" class="status-dot" />
+        </view>
+        <text class="label" :class="{ active: isActive(tab.key) }">{{ tab.label }}</text>
+      </view>
     </button>
   </view>
   <view class="ctb-safe"/>
@@ -19,8 +23,15 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 
+const tabs = [
+  { key: 'stats', label: '统计', url: '/pages/stats/index', icon: '/static/icons/tab-stats.svg' },
+  { key: 'index', label: '程序', url: '/pages/index/index', icon: '/static/icons/tab-game.svg' },
+  { key: 'user', label: '用户', url: '/pages/user/index', icon: '/static/icons/tab-user.svg' }
+]
+
 const currentPath = ref('')
 const wrapStyle = ref('')
+const SAFE_EXTRA_PX = 20
 
 onMounted(() => {
   try {
@@ -30,7 +41,9 @@ onMounted(() => {
   try {
     const sys = uni.getSystemInfoSync && uni.getSystemInfoSync()
     const hb = (sys && sys.safeAreaInsets && sys.safeAreaInsets.bottom) || 0
-    wrapStyle.value = `padding-bottom:${hb ? hb + 'px' : 'env(safe-area-inset-bottom)'}`
+    wrapStyle.value = hb
+      ? `padding-bottom:${hb + SAFE_EXTRA_PX}px`
+      : `padding-bottom:calc(env(safe-area-inset-bottom) + ${SAFE_EXTRA_PX}px)`
   } catch (_) {}
   // 监听全局路由同步事件，确保返回/手势返回后高亮状态更新
   try { uni.$off && uni.$off('tabbar:update', updatePath) } catch(_) {}
@@ -115,67 +128,128 @@ function go(url){
 </script>
 
 <style scoped>
-.ctb { 
-  position: fixed; 
-  left: 0; 
-  right: 0; 
-  bottom: 0; 
-  z-index: 999; 
-  display: grid; 
-  grid-template-columns: repeat(3, 1fr); 
-  background: #ffffff; 
-  box-shadow: 0 -6rpx 16rpx rgba(15,23,42,.06); 
-  padding: 10rpx 8rpx; 
-  transition: background-color 0.3s ease;
-}
-.ctb-safe { height: env(safe-area-inset-bottom); }
-.ctb-item { 
-  background: transparent; 
-  border: none; 
-  display: flex; 
-  flex-direction: column; 
-  align-items: center; 
-  justify-content: center; 
-  width: 25dvw;
-  padding: 10rpx 0; 
-  gap: 6rpx; 
-  transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  border-radius: 12rpx;
+.ctb {
+  position: fixed;
+  left: 24rpx;
+  right: 24rpx;
+  bottom: 24rpx;
+  z-index: 999;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12rpx;
+  padding: 22rpx 26rpx;
+  border-radius: 40rpx;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.72) 0%, rgba(30, 41, 59, 0.55) 100%);
+  box-shadow: 0 26rpx 60rpx rgba(15, 23, 42, 0.32);
+  border: 1rpx solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(30rpx);
+  -webkit-backdrop-filter: blur(30rpx);
   overflow: visible;
+  isolation: isolate;
+  transition: box-shadow 0.35s ease, background 0.35s ease;
+}
+.ctb::after {
+  content: '';
+  position: absolute;
+  inset: 1rpx;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(148, 163, 184, 0.08));
+  opacity: 0.22;
+  z-index: 0;
+}
+.ctb-safe {
+  height: calc(env(safe-area-inset-bottom) + 180rpx);
+}
+.ctb-item {
+  position: relative;
+  background: rgba(255, 255, 255, 0.02);
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12rpx 6rpx;
+  border-radius: 26rpx;
+  transition: transform 0.24s cubic-bezier(0.22, 0.61, 0.36, 1), box-shadow 0.24s ease, background 0.24s ease;
   appearance: none;
   -webkit-appearance: none;
   outline: none;
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1rpx rgba(255, 255, 255, 0.05);
+  overflow: visible;
+  z-index: 1;
 }
-.ctb-item::after {
-  border: none !important;
-  border-width: 0 !important;
-  background: transparent !important;
+.ctb-item-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8rpx;
 }
 .ctb-item:active {
-  transform: scale(0.8);
-  background: rgba(58, 122, 254, 0.08);
+  transform: translateY(4rpx) scale(0.96);
+  box-shadow: inset 0 0 0 1rpx rgba(148, 163, 184, 0.14);
 }
-.icon { 
-  font-size: 28rpx; 
-  line-height: 1; 
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  filter: grayscale(1) opacity(0.6);
+.ctb-item.active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.24), rgba(96, 165, 250, 0.14));
+  box-shadow: 0 18rpx 38rpx rgba(59, 130, 246, 0.3), 0 0 0 1rpx rgba(148, 163, 184, 0.25) inset;
 }
-.icon.active {
-  transform: scale(1.2);
-  filter: grayscale(0) opacity(1);
+.ctb-item.active:active {
+  transform: translateY(2rpx) scale(0.98);
 }
-.label { 
-  font-size: 28rpx; 
-  font-weight: 800; 
-  color: #94a3b8; /* 未选中为灰 */
-  transition: all 0.2s ease;
-  white-space: nowrap;
-  overflow: visible;
+.icon-shell {
+  position: relative;
+  width: 76rpx;
+  height: 76rpx;
+  border-radius: 24rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.42);
+  box-shadow: inset 0 0 0 1rpx rgba(255, 255, 255, 0.15);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
-.label.active { 
-  transform: scale(1.2);
-  color: #0953e9; /* 选中为主色 */
+.icon-shell.active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.78), rgba(96, 165, 250, 0.64));
+  box-shadow: 0 12rpx 26rpx rgba(37, 99, 235, 0.45), inset 0 0 0 1rpx rgba(255, 255, 255, 0.35);
+  transform: translateY(-4rpx) scale(1.06);
+}
+.icon-img {
+  width: 44rpx;
+  height: 44rpx;
+}
+.badge {
+  position: absolute;
+  top: -6rpx;
+  right: -4rpx;
+  min-width: 32rpx;
+  padding: 2rpx 8rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(135deg, #f97316, #fbbf24);
+  color: #0f172a;
+  font-size: 20rpx;
+  font-weight: 800;
+  box-shadow: 0 10rpx 20rpx rgba(249, 115, 22, 0.35);
+}
+.status-dot {
+  position: absolute;
+  top: -2rpx;
+  right: 2rpx;
+  width: 18rpx;
+  height: 18rpx;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #34d399, #10b981);
+  box-shadow: 0 8rpx 14rpx rgba(16, 185, 129, 0.45);
+}
+.label {
+  font-size: 26rpx;
+  font-weight: 700;
+  color: rgba(226, 232, 240, 0.78);
+  letter-spacing: 2rpx;
+  transition: transform 0.24s ease, color 0.24s ease;
+}
+.label.active {
+  color: #f8fafc;
+  text-shadow: 0 4rpx 18rpx rgba(59, 130, 246, 0.75);
+  transform: translateY(-2rpx) scale(1.08);
 }
 </style>

--- a/static/icons/tab-game.svg
+++ b/static/icons/tab-game.svg
@@ -1,0 +1,26 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="20" width="68" height="56" rx="20" fill="url(#paint0_linear)" opacity="0.18" />
+  <path d="M36 34h24c7.732 0 14 6.268 14 14v8c0 7.732-6.268 14-14 14H36c-7.732 0-14-6.268-14-14v-8c0-7.732 6.268-14 14-14Z" fill="url(#paint1_linear)" stroke="url(#paint2_linear)" stroke-width="3"/>
+  <path d="M38 56h-4v-4m0 0v-4h4m-4 4h4" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.92"/>
+  <circle cx="58" cy="50" r="4" fill="#FACC15"/>
+  <circle cx="66" cy="58" r="4" fill="#22D3EE"/>
+  <path d="M44 40h8" stroke="url(#paint3_linear)" stroke-width="4" stroke-linecap="round" opacity="0.6"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="14" y1="20" x2="82" y2="76" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366F1" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#A855F7" stop-opacity="0.35"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="24" y1="32" x2="72" y2="72" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4C1D95"/>
+      <stop offset="1" stop-color="#4338CA"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="24" y1="32" x2="72" y2="72" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C4B5FD"/>
+      <stop offset="1" stop-color="#DDD6FE"/>
+    </linearGradient>
+    <linearGradient id="paint3_linear" x1="44" y1="40" x2="52" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE68A"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/static/icons/tab-stats.svg
+++ b/static/icons/tab-stats.svg
@@ -1,0 +1,23 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="18" width="68" height="60" rx="16" fill="url(#paint0_linear)" opacity="0.16" />
+  <path d="M26 62V50c0-2.2 1.8-4 4-4h4c2.2 0 4 1.8 4 4v12c0 2.2-1.8 4-4 4h-4c-2.2 0-4-1.8-4-4Zm18 0V38c0-2.2 1.8-4 4-4h4c2.2 0 4 1.8 4 4v24c0 2.2-1.8 4-4 4h-4c-2.2 0-4-1.8-4-4Zm18 0V30c0-2.2 1.8-4 4-4h4c2.2 0 4 1.8 4 4v32c0 2.2-1.8 4-4 4h-4c-2.2 0-4-1.8-4-4Z" fill="url(#paint1_linear)" stroke="url(#paint2_linear)" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M26 28h44" stroke="url(#paint3_linear)" stroke-width="6" stroke-linecap="round" opacity="0.32"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="14" y1="18" x2="82" y2="78" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3B82F6" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="#60A5FA" stop-opacity="0.4"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="26" y1="26" x2="70" y2="70" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#60A5FA"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="26" y1="26" x2="70" y2="70" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#93C5FD"/>
+      <stop offset="1" stop-color="#BFDBFE"/>
+    </linearGradient>
+    <linearGradient id="paint3_linear" x1="26" y1="28" x2="70" y2="28" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E0F2FE"/>
+      <stop offset="1" stop-color="#BFDBFE"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/static/icons/tab-user.svg
+++ b/static/icons/tab-user.svg
@@ -1,0 +1,27 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="14" width="64" height="68" rx="24" fill="url(#paint0_linear)" opacity="0.18" />
+  <path d="M48 28c7.18 0 13 5.82 13 13s-5.82 13-13 13-13-5.82-13-13 5.82-13 13-13Z" fill="url(#paint1_linear)" stroke="url(#paint2_linear)" stroke-width="2.5"/>
+  <path d="M30 68.5c2.3-10.2 11.7-17.5 23-17.5s20.7 7.3 23 17.5c.4 1.8-.8 3.5-2.7 3.5H32.7c-1.9 0-3.1-1.7-2.7-3.5Z" fill="url(#paint3_linear)" stroke="url(#paint4_linear)" stroke-width="2" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="16" y1="14" x2="80" y2="82" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EA5E9" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0.35"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="35" y1="28" x2="61" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0284C7"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="35" y1="28" x2="61" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#BAE6FD"/>
+      <stop offset="1" stop-color="#CFFAFE"/>
+    </linearGradient>
+    <linearGradient id="paint3_linear" x1="30" y1="51" x2="72" y2="72" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0369A1"/>
+      <stop offset="1" stop-color="#0891B2"/>
+    </linearGradient>
+    <linearGradient id="paint4_linear" x1="30" y1="51" x2="72" y2="72" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7DD3FC"/>
+      <stop offset="1" stop-color="#67E8F9"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/uni.scss
+++ b/uni.scss
@@ -1,10 +1,72 @@
 /* 自定义主题变量或全局样式（使用原生 CSS 变量，避免预处理器依赖） */
-:root { --primary: #3a7afe; --text: #333; }
+:root {
+  --primary: #3a7afe;
+  --primary-strong: #2563eb;
+  --primary-soft: #60a5fa;
+  --text: #333;
+  --btn-radius: 20rpx;
+  --btn-shadow: 0 18rpx 40rpx rgba(37, 99, 235, 0.28);
+  --btn-secondary-shadow: 0 14rpx 28rpx rgba(148, 163, 184, 0.26);
+}
 
 /* 简易按钮样式（兼容 H5/APP/小程序） */
-.btn { padding: 20rpx 28rpx; border-radius: 12rpx; font-size: 28rpx; border:2rpx solid transparent; }
-.btn-primary { background-color: var(--primary); color: #fff; border-color: var(--primary); }
-.btn-secondary { background-color: #fff; color: var(--primary); border: 2rpx solid var(--primary); }
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12rpx;
+  width: 100%;
+  padding: 24rpx 36rpx;
+  border-radius: var(--btn-radius);
+  font-size: 30rpx;
+  font-weight: 700;
+  line-height: 1.1;
+  border: 2rpx solid transparent;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(241, 245, 249, 0.86));
+  color: #0f172a;
+  box-shadow: 0 14rpx 30rpx rgba(15, 23, 42, 0.14);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  text-align: center;
+}
+.btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 10%, rgba(255, 255, 255, 0.65), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+.btn:active {
+  transform: translateY(2rpx) scale(0.98);
+  box-shadow: 0 10rpx 20rpx rgba(15, 23, 42, 0.2);
+  filter: saturate(1.1);
+}
+.btn:active::after {
+  opacity: 0.28;
+}
+.btn-primary {
+  background: linear-gradient(135deg, var(--primary-strong) 0%, var(--primary) 45%, var(--primary-soft) 100%);
+  color: #f8fafc;
+  box-shadow: var(--btn-shadow);
+}
+.btn-secondary {
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.94), rgba(226, 232, 240, 0.92));
+  color: #0f172a;
+  border-color: rgba(148, 163, 184, 0.38);
+  box-shadow: var(--btn-secondary-shadow);
+}
+.btn-secondary:active {
+  border-color: rgba(148, 163, 184, 0.58);
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--primary-strong);
+  border: 2rpx solid var(--primary-strong);
+  box-shadow: none;
+}
 .row { display: flex; flex-direction: row; align-items: center; }
 .col { display: flex; flex-direction: column; }
 .space-between { justify-content: space-between; }


### PR DESCRIPTION
## Summary
- replace the tab bar emoji with dedicated SVG icons and expose badge/dot support in the template
- restyle the custom tab bar with a glassmorphism base, rounded footing and richer active animations
- align global button gradients and active feedback so secondary actions keep contrast on dark surfaces

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfaec64b84832385e1325809ff55d7