### PR TITLE
feat: refresh login and user UI with themed avatars

### DIFF
--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -6,57 +6,96 @@
     @touchend="edgeHandlers.handleTouchEnd"
     @touchcancel="edgeHandlers.handleTouchCancel"
   >
-    <!-- 顶部栏 -->
     <view class="login-topbar">
-      <!-- <button class="icon-btn" @tap="goBack">←</button> -->
       <text class="login-title">无敌24点程序·观测</text>
-      <!-- <view style="width:40rpx"></view> -->
     </view>
 
-    <!-- 主体 -->
     <view class="login-body">
       <view class="login-heading">
         <text class="h1">选择玩家</text>
+        <text class="heading-desc">独立记录每位玩家的闯关成绩</text>
       </view>
 
-      <!-- 错误状态 -->
       <view v-if="errMsg" class="error-card card section">
         <text class="err-title">数据异常</text>
         <text class="err-text">{{ errMsg }}</text>
         <button class="btn danger" @tap="resetData">重置数据</button>
       </view>
 
-      <!-- 空状态 -->
       <view v-else-if="(sortedUsers.length === 0)" class="empty-card card section">
-        <text class="empty-ill">🃏</text>
-        <text class="empty-text">还没有玩家，快创建一个吧！</text>
-        <button class="create-btn highlight" @tap="createUser">
-          <text class="create-plus">＋</text>
-          <text>新建玩家</text>
-        </button>
+        <view class="empty-card-inner">
+          <text class="empty-badge">欢迎加入</text>
+          <text class="empty-ill">🃏</text>
+          <text class="empty-text">还没有玩家，快创建一个吧！</text>
+          <text class="empty-desc">我们会为每位玩家准备专属统计面板</text>
+          <button class="create-btn highlight" @tap="createUser">
+            <text class="create-plus">＋</text>
+            <text>新建玩家</text>
+          </button>
+        </view>
       </view>
 
-      <!-- 用户列表 -->
       <view v-else class="user-list">
-        <button class="user-item card section" v-for="u in sortedUsers" :key="u.id" @tap="choose(u)">
-          <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
-          <view v-else class="avatar" :style="{ backgroundColor: u.color || colorFrom(u) }">{{ avatarText(u.name) }}</view>
-          <view class="user-col">
-            <view class="user-name">{{ u.name }}</view>
-            <view class="user-sub">最近程序：{{ lastPlayedText(u.lastPlayedAt) }}</view>
-              <!-- </text>
-            </text> -->
+        <view class="list-guide">
+          <text class="guide-badge">提示</text>
+          <text class="guide-text">点选卡片即可进入程序，当前角色的对局将被优先记录。</text>
+        </view>
+        <button
+          class="user-item card section"
+          v-for="(u, idx) in sortedUsers"
+          :key="u.id"
+          @tap="choose(u)"
+          :style="userCardStyle(u, idx)"
+        >
+          <view class="user-item-inner">
+            <view class="avatar-wrapper">
+              <view class="avatar-ring" :style="avatarRingStyle(u)">
+                <image
+                  v-if="u.avatar"
+                  class="avatar-img"
+                  :src="u.avatar"
+                  mode="aspectFill"
+                />
+                <view v-else class="avatar-generated">
+                  <image class="avatar-pattern" :src="defaultAvatarFor(u).uri" mode="aspectFill" />
+                  <text class="avatar-initial" :style="{ color: defaultAvatarFor(u).palette.text }">
+                    {{ avatarText(u.name) }}
+                  </text>
+                </view>
+              </view>
+              <text
+                v-if="users.currentId === u.id"
+                class="avatar-badge"
+                :style="badgeStyle(u, 'active')"
+              >当前</text>
+              <text
+                v-else-if="idx === 0"
+                class="avatar-badge"
+                :style="badgeStyle(u, 'recent')"
+              >常用</text>
+            </view>
+            <view class="user-col">
+              <view class="user-name-row">
+                <text class="user-name">{{ u.name }}</text>
+              </view>
+              <view class="user-sub-row">
+                <text class="user-meta-label">最近游玩</text>
+                <text class="user-meta-value">{{ lastPlayedText(u.lastPlayedAt) }}</text>
+              </view>
+              <text class="user-hint" :style="{ color: defaultAvatarFor(u).palette.overlay }">点击卡片即可快速进入</text>
+            </view>
+            <view class="chev-box">
+              <text class="chev">›</text>
+            </view>
           </view>
-          <text class="chev">›</text>
         </button>
-        <button class="create-btn" @tap="createUser">
+        <button class="create-btn ghost" @tap="createUser">
           <text class="create-plus">＋</text>
           <text>新建玩家</text>
         </button>
       </view>
     </view>
 
-    <!-- 底部区块：原“以游客登录”入口已移除 -->
     <view
       v-if="hintState.visible"
       class="floating-hint-layer"
@@ -71,7 +110,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { ensureInit, getUsers, addUser, switchUser, resetAllData, touchLastPlayed } from '../../utils/store.js'
-import { saveAvatarForUser } from '../../utils/avatar.js'
+import { saveAvatarForUser, generateDefaultAvatar } from '../../utils/avatar.js'
 import { useFloatingHint } from '../../utils/hints.js'
 import { useEdgeExit } from '../../utils/edge-exit.js'
 import { exitApp } from '../../utils/navigation.js'
@@ -82,12 +121,59 @@ const errMsg = ref('')
 const { hintState, showHint, hideHint } = useFloatingHint()
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitLoginPage() })
 
+const defaultAvatarCache = new Map()
+const FALLBACK_AVATAR = generateDefaultAvatar('tf24-default', { size: 128 })
+
 onMounted(() => {
   ensureInit();
   safeLoad();
   try { updateVHVar() } catch(_) {}
   if (uni.onWindowResize) uni.onWindowResize(() => { try { updateVHVar() } catch(_) {} })
 })
+
+function defaultAvatarFor(user) {
+  if (!user) return FALLBACK_AVATAR
+  const key = `${user.id || ''}|${user.name || ''}|${user.color || ''}`
+  if (!defaultAvatarCache.has(key)) {
+    defaultAvatarCache.set(key, generateDefaultAvatar(key, { size: 128 }))
+  }
+  return defaultAvatarCache.get(key) || FALLBACK_AVATAR
+}
+
+function userCardStyle(user, index = 0) {
+  const theme = defaultAvatarFor(user)
+  const style = {
+    background: theme.panelGradient,
+    borderColor: theme.borderColor,
+    boxShadow: theme.shadow
+  }
+  if (users.value && users.value.currentId === user.id) {
+    style.borderColor = theme.palette.accent
+  }
+  if (index === 0) {
+    style.boxShadow = `0 30rpx 60rpx ${theme.softShadow}`
+  }
+  return style
+}
+
+function avatarRingStyle(user) {
+  const theme = defaultAvatarFor(user)
+  return {
+    borderColor: theme.borderColor,
+    boxShadow: `0 12rpx 24rpx ${theme.softShadow}`,
+    background: '#ffffff'
+  }
+}
+
+function badgeStyle(user, mode = 'active') {
+  const theme = defaultAvatarFor(user)
+  const gradient = mode === 'recent' ? theme.altBadgeGradient : theme.badgeGradient
+  return {
+    background: gradient,
+    color: theme.palette.badgeText,
+    boxShadow: `0 12rpx 24rpx ${theme.badgeShadow}`
+  }
+}
 
 function updateVHVar(){
   try {
@@ -102,7 +188,6 @@ function updateVHVar(){
 function safeLoad(){
   try {
     const u = getUsers()
-    // 简单校验结构
     if (!u || !Array.isArray(u.list) || u.currentId === undefined) {
       throw new Error('本地用户数据结构无效')
     }
@@ -113,7 +198,6 @@ function safeLoad(){
 }
 
 const sortedUsers = computed(() => {
-  // 过滤掉历史上可能遗留的“Guest/游客”记录，不在列表中展示
   const list = (users.value.list || []).filter(u => String(u.name||'') !== 'Guest').slice()
   list.sort((a,b) => (b.lastPlayedAt||0) - (a.lastPlayedAt||0) || (b.createdAt||0) - (a.createdAt||0))
   return list
@@ -121,11 +205,9 @@ const sortedUsers = computed(() => {
 
 function refresh() { safeLoad() }
 function go(url){
-  // 登录流程进入首页：使用 reLaunch 清空栈，避免出现系统返回按钮
   try { uni.reLaunch({ url }) }
   catch(_) { try { uni.switchTab({ url }) } catch(_) {} }
 }
-// function goBack() { try { uni.navigateBack() } catch(e) { go('/pages/index/index') } }
 function choose(u) { switchUser(u.id); touchLastPlayed(u.id); go('/pages/index/index') }
 function createUser() {
   uni.showModal({ title:'新建玩家', editable:true, placeholderText:'昵称（1-20字）', success(res){
@@ -134,7 +216,8 @@ function createUser() {
     if (!name || name.length < 1 || name.length > 20) { uni.showToast({ title:'请输入1-20字昵称', icon:'none' }); return }
     const exists = (users.value.list||[]).some(x => String(x.name||'').toLowerCase() === name.toLowerCase())
     if (exists) {
-      uni.showModal({ title:'提示', content:'已有同名玩家，是否继续创建？', success(r2){ if (r2.confirm) stepChooseAvatar(name); else createUser() } })
+      uni.showModal({ title:'提示', content:'已有同名玩家，是否继续创建？', success(r2){ if (r2.confirm) stepChooseAvatar(name);
+ else createUser() } })
     } else {
       stepChooseAvatar(name)
     }
@@ -150,11 +233,10 @@ function stepChooseAvatar(name){
         finalizeCreate(name, path, size)
       }, fail(){ finalizeCreate(name, '') } })
     } else if (idx === 2) {
-      finalizeCreate(name, '') // 我们用随机背景色
+      finalizeCreate(name, '')
     } else if (idx === 3) {
       finalizeCreate(name, '')
     }
-    // idx === 0 就是点了“标题”，这里通常不处理
   }, fail(){ finalizeCreate(name, '') } })
 }
 function finalizeCreate(name, avatar, size){
@@ -201,147 +283,416 @@ function lastPlayedText(ts){
     return `${y}-${m}-${day} ${hh}:${mm}`
   } catch(_) { return '时间未知' }
 }
-function colorFrom(u){
-  const base = String(u.id || u.name || '')
-  let hash = 0; for (let i=0;i<base.length;i++){ hash = (hash*33 + base.charCodeAt(i))>>>0 }
-  const palette = ['#e2e8f0','#fde68a','#bbf7d0','#bfdbfe','#fecaca','#f5d0fe','#c7d2fe']
-  return palette[hash % palette.length]
-}
 function resetData(){
   uni.showModal({ title:'重置数据', content:'将清空本地所有数据，是否继续？', success(res){ if(res.confirm){ resetAllData(); errMsg.value=''; refresh() } } })
 }
 </script>
 
 <style scoped>
- .login-page {
-  /* 视口高度填满，兼容移动端动态地址栏 */
+.login-page {
   min-height: 100dvh;
   min-height: calc(var(--vh, 1vh) * 100);
-  background: #f1f5f9;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 55%, #f1f5f9 100%);
   display: flex;
   flex-direction: column;
-  overflow: hidden;  /* 防止整体滚动 */
+  overflow: hidden;
 }
 body {
   overflow: hidden;
   height: 100vh;
 }
-.login-topbar{ display:flex; align-items:center; padding:24rpx; gap:12rpx }
-/* .icon-btn{ width:64rpx; height:64rpx; border-radius:50%; background:#e5e7eb; display:flex; align-items:center; justify-content:center; border:none; } */
-.login-title{ flex:1; text-align:center; font-weight:900; font-size:36rpx; color:#0e141b; letter-spacing:-0.5rpx }
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-.login-body {
-  flex: 1;  /* 占据剩余空间 */
-  padding: 10rpx 2.5rpx 0 2.5rpx;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;  /* 防止溢出 */
-  min-height: 0;  /* 允许收缩 */
-  height: 0;  /* 强制高度约束 */
-}
-.login-heading { 
-  flex-shrink: 0;  /* 不收缩 */
-  text-align: center; 
-  margin: 0rpx 0 24rpx 0;
-  height: 80rpx;  /* 固定高度 */
+.login-topbar {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 24rpx 32rpx;
 }
-.h1{ font-size:56rpx; font-weight:900; color:#0e141b }
+.login-title {
+  font-weight: 900;
+  font-size: 36rpx;
+  color: #0e141b;
+  letter-spacing: -0.5rpx;
+}
+.floating-hint-layer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 999;
+}
+.floating-hint-layer.interactive {
+  pointer-events: auto;
+}
+.floating-hint {
+  max-width: 70%;
+  background: rgba(15,23,42,0.86);
+  color: #fff;
+  padding: 24rpx 36rpx;
+  border-radius: 24rpx;
+  text-align: center;
+  font-size: 30rpx;
+  box-shadow: 0 20rpx 48rpx rgba(15,23,42,0.25);
+  backdrop-filter: blur(12px);
+}
+.login-body {
+  flex: 1;
+  padding: 0 32rpx 32rpx 32rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  overflow: hidden;
+  position: relative;
+}
+.login-body::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(148,163,184,0.18), transparent 55%);
+  pointer-events: none;
+}
+.login-heading {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12rpx;
+  margin-top: 12rpx;
+}
+.h1 {
+  font-size: 56rpx;
+  font-weight: 900;
+  color: #0e141b;
+}
+.heading-desc {
+  font-size: 26rpx;
+  color: #475569;
+}
 .user-list {
+  position: relative;
+  z-index: 1;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 20rpx;
-  padding: 0 100rpx 20rpx 100rpx;  /* 改为padding，不用margin */
+  gap: 24rpx;
+  padding: 0 20rpx 24rpx 20rpx;
   overflow-y: auto;
   min-height: 0;
-  height: 0;  /* 强制高度约束 */
 }
-/* 滚动条样式优化 */
 .user-list::-webkit-scrollbar {
   width: 6rpx;
 }
-
 .user-list::-webkit-scrollbar-track {
   background: transparent;
 }
-
 .user-list::-webkit-scrollbar-thumb {
   background: #cbd5e1;
   border-radius: 3rpx;
 }
-
 .user-list::-webkit-scrollbar-thumb:hover {
   background: #94a3b8;
 }
-.user-item{ display:flex; align-items:center; padding:10rpx; height:100rpx;width:100%; border-radius:12rpx; border:2rpx solid #cfd8e3; background:#ffffff; box-shadow:0 2rpx 4rpx rgba(15,23,42,0.02) }
-.user-item:active{ transform:scale(0.98) }
-.avatar{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#0f172a; margin-right:20rpx }
-.avatar-img{ width:72rpx; height:72rpx; border-radius:50%; margin-right:20rpx; background:#e2e8f0 }
-.user-col{
-  flex:1;
-  display:grid;
-  /* 方案A：定宽（最稳妥，确保“最近程序”纵向齐） */
-  grid-template-columns: minmax(0, 200rpx) 1fr;  /* ← 原来是 auto 1fr */
-  /* 也可用半定宽：grid-template-columns: minmax(240rpx, 36vw) 1fr; 
-     （注意小程序端对 clamp/minmax 的兼容性，H5/App 正常） */
-  align-items:left;
-  justify-items:start;                /* ✅ 内容在各列内靠左 */
-  column-gap:10rpx; 
-  min-width:0;
+.list-guide {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+  background: rgba(148,163,184,0.14);
+  border: 2rpx dashed rgba(148,163,184,0.35);
+  border-radius: 18rpx;
+  padding: 16rpx 20rpx;
+  color: #475569;
+  font-size: 24rpx;
 }
-.user-name {
-  font-size:34rpx;
-  color:#0f172a;
-  font-weight:700;
-  white-space:nowrap;               /* ✅ 不换行 */
-  overflow:hidden;
-  text-overflow:ellipsis;           /* ✅ 超长省略号 */
-  text-align:left;                    /* ✅ 明确指定左对齐 */
-  width: 100%;      /* 关键修复 */
-  max-width: 100%;  /* 双重保险 */
+.guide-badge {
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 999rpx;
+  padding: 4rpx 18rpx;
+  font-size: 22rpx;
 }
-.user-sub {
-  font-size:20rpx;
-  color:#64748b;
-  white-space:nowrap;
-  align-self:center;                     /* ✅ 单独确保这一列底对齐 */
+.user-item {
+  position: relative;
+  border-radius: 28rpx;
+  border: 2rpx solid transparent;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  padding: 18rpx 26rpx;
+  overflow: hidden;
 }
-.chev{
-  flex:0 0 auto;          /* 不要挤压中间列 */
-  width: 40rpx;           /* 可选：固定宽度，视觉更稳 */
-  text-align:right;
-  color:#94a3b8; font-size:40rpx; font-weight:800; margin-left:12rpx;
+.user-item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2rpx solid rgba(255,255,255,0.3);
+  pointer-events: none;
 }
-.create-btn{ margin-top:20rpx; height:100rpx; border-radius:24rpx; background:#e2e8f0; color:#0f172a; font-size:32rpx; font-weight:800; border:none; display:flex; align-items:center; justify-content:center; gap:12rpx }
-.create-btn.highlight{ background:#145751; color:#fff }
-.create-plus{ font-size:36rpx }
-/* 底部区块相关样式已移除（guest 入口下线） */
-button{ -webkit-tap-highlight-color:rgba(0,0,0,0) }
-
-/* 空/错 视图 */
-.empty-card, .error-card {
-  flex: 1;  /* 占据可用空间 */
+.user-item:active {
+  transform: scale(0.97);
+}
+.user-item-inner {
+  display: flex;
+  align-items: center;
+  gap: 24rpx;
+}
+.avatar-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;  /* 垂直居中 */
-  gap: 16rpx;
-  padding: 40rpx 24rpx;
-  margin: 50rpx 100rpx;
-  border-radius: 24rpx;
-  background: #fff;
-  border: 2rpx solid #e5e7eb;
-  max-height: 100%;  /* 不超出容器 */
-  overflow-y: auto;  /* 如果内容过多也能滚动 */
+  gap: 10rpx;
 }
-.empty-ill{ font-size:88rpx }
-.empty-text{ color:#6b7280 }
-.err-title{ font-weight:800; color:#b91c1c }
-.err-text{ color:#6b7280; text-align:center }
-.btn.danger{ background:#ef4444; color:#fff; border:none; padding:20rpx 28rpx; border-radius:14rpx }
+.avatar-ring {
+  width: 96rpx;
+  height: 96rpx;
+  border-radius: 50%;
+  border: 4rpx solid rgba(255,255,255,0.6);
+  padding: 8rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.avatar-img,
+.avatar-generated {
+  width: 80rpx;
+  height: 80rpx;
+  border-radius: 50%;
+  overflow: hidden;
+  position: relative;
+}
+.avatar-generated {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.avatar-pattern {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.avatar-initial {
+  font-weight: 800;
+  font-size: 32rpx;
+  z-index: 1;
+}
+.avatar-badge {
+  font-size: 22rpx;
+  padding: 4rpx 16rpx;
+  border-radius: 999rpx;
+  font-weight: 700;
+  color: #fff;
+  backdrop-filter: blur(6rpx);
+}
+.user-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10rpx;
+  min-width: 0;
+}
+.user-name-row {
+  display: flex;
+  align-items: center;
+  gap: 10rpx;
+}
+.user-name {
+  font-size: 36rpx;
+  color: #0f172a;
+  font-weight: 800;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.user-sub-row {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+  font-size: 24rpx;
+  color: #475569;
+}
+.user-meta-label {
+  font-weight: 600;
+  opacity: 0.72;
+}
+.user-meta-value {
+  font-weight: 600;
+}
+.user-hint {
+  font-size: 22rpx;
+  color: #64748b;
+}
+.chev-box {
+  width: 56rpx;
+  height: 56rpx;
+  border-radius: 18rpx;
+  background: rgba(255,255,255,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.chev {
+  color: rgba(15,23,42,0.55);
+  font-size: 44rpx;
+  font-weight: 800;
+}
+.create-btn {
+  height: 104rpx;
+  border-radius: 28rpx;
+  background: rgba(226,232,240,0.8);
+  color: #0f172a;
+  font-size: 32rpx;
+  font-weight: 800;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12rpx;
+  transition: transform 0.18s ease;
+}
+.create-btn:active {
+  transform: scale(0.97);
+}
+.create-btn.highlight {
+  background: linear-gradient(135deg, #0f766e, #14b8a6);
+  color: #fff;
+  box-shadow: 0 18rpx 40rpx rgba(20, 184, 166, 0.25);
+}
+.create-btn.ghost {
+  background: rgba(148,163,184,0.18);
+  color: #0f172a;
+}
+.create-plus {
+  font-size: 36rpx;
+}
+.empty-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40rpx 32rpx;
+  border-radius: 32rpx;
+  border: 2rpx solid rgba(148,163,184,0.35);
+  overflow: hidden;
+}
+.empty-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(56,189,248,0.16), rgba(59,130,246,0.08));
+}
+.empty-card-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16rpx;
+  text-align: center;
+  z-index: 1;
+}
+.empty-badge {
+  padding: 6rpx 20rpx;
+  border-radius: 999rpx;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #fff;
+  font-weight: 700;
+  font-size: 22rpx;
+}
+.empty-ill {
+  font-size: 96rpx;
+}
+.empty-text {
+  color: #0f172a;
+  font-size: 32rpx;
+  font-weight: 700;
+}
+.empty-desc {
+  color: #475569;
+  font-size: 24rpx;
+}
+.error-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16rpx;
+  padding: 36rpx 24rpx;
+  border-radius: 28rpx;
+  border: 2rpx solid rgba(248,113,113,0.35);
+  background: linear-gradient(135deg, rgba(254,226,226,0.55), rgba(252,165,165,0.35));
+}
+.err-title {
+  font-weight: 800;
+  color: #b91c1c;
+  font-size: 32rpx;
+}
+.err-text {
+  color: #6b7280;
+  text-align: center;
+  font-size: 26rpx;
+}
+.btn.danger {
+  background: #ef4444;
+  color: #fff;
+  border: none;
+  padding: 20rpx 28rpx;
+  border-radius: 14rpx;
+}
+button {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+@media screen and (min-width: 900px) {
+  .login-body {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 40rpx;
+    padding: 20rpx 80rpx 60rpx 80rpx;
+  }
+  .login-heading {
+    width: 320rpx;
+    align-items: flex-start;
+    text-align: left;
+    margin-top: 60rpx;
+  }
+  .user-list {
+    max-width: 760rpx;
+    padding: 0 40rpx 40rpx 40rpx;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .login-body {
+    padding: 0 16rpx 24rpx 16rpx;
+  }
+  .user-item-inner {
+    gap: 20rpx;
+  }
+  .user-item {
+    padding: 16rpx 20rpx;
+  }
+  .avatar-ring {
+    width: 88rpx;
+    height: 88rpx;
+    padding: 6rpx;
+  }
+  .avatar-img,
+  .avatar-generated {
+    width: 72rpx;
+    height: 72rpx;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .user-item-inner {
+    align-items: flex-start;
+  }
+  .chev-box {
+    margin-left: auto;
+  }
+}
 </style>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -1,27 +1,76 @@
-﻿<template>
-  <view class="page" style="padding:24rpx; display:flex; flex-direction:column; gap:16rpx;"
+<template>
+  <view class="page"
         @touchstart="edgeHandlers.handleTouchStart"
         @touchmove="edgeHandlers.handleTouchMove"
         @touchend="edgeHandlers.handleTouchEnd"
         @touchcancel="edgeHandlers.handleTouchCancel">
-    <view class="row" style="gap:12rpx; align-items:center;">
-      <input v-model="newName" placeholder="新用户名称" class="input" />
-      <button class="btn btn-primary" @tap="create">添加</button>
+    <view class="management-hero card section">
+      <view class="hero-top">
+        <text class="hero-title">管理角色</text>
+        <text class="hero-sub">维护玩家昵称与头像，切换当前操作者。</text>
+      </view>
+      <view class="hero-note">
+        <text class="hero-tag">说明</text>
+        <text class="hero-desc">列表按最近游玩排序，当前角色会自动高亮。</text>
+      </view>
     </view>
-    <view class="list">
-      <view v-for="u in visibleUsers" :key="u.id" class="item card section" :class="{ active: u.id===users.currentId }">
-        <view class="user-left" @tap="choose(u.id)">
-          <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
-          <view v-else class="avatar" :style="{ backgroundColor: u.color || '#e2e8f0' }">{{ avatarText(u.name) }}</view>
-          <view class="name">{{ u.name }}</view>
-        </view>
-        <view class="ops">
-          <button class="mini" @tap="rename(u)">改名</button>
-          <button class="mini" @tap="changeAvatar(u)">头像</button>
-          <button class="mini danger" @tap="remove(u.id)">删除</button>
+
+    <view class="create-panel card section">
+      <view class="create-header">
+        <text class="create-title">快速添加</text>
+        <text class="create-hint">输入昵称后点击“添加”即可创建新角色，稍后可在列表中完善头像。</text>
+      </view>
+      <view class="create-row">
+        <input v-model="newName" placeholder="新用户名称" class="input" />
+        <button class="btn btn-primary" @tap="create">添加</button>
+      </view>
+    </view>
+
+    <view class="list-card card section">
+      <view class="list-header">
+        <text class="list-title">角色列表</text>
+        <text class="list-sub">轻触左侧卡片可立即切换，右侧按钮用于编辑资料。</text>
+      </view>
+      <view class="list">
+        <view v-for="(u, idx) in visibleUsers" :key="u.id" class="item card section"
+              :class="{ active: u.id===users.currentId }"
+              :style="userCardStyle(u, idx)">
+          <view class="item-left" @tap="choose(u.id)">
+            <view class="avatar-wrapper">
+              <view class="avatar-ring" :style="avatarRingStyle(u)">
+                <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
+                <view v-else class="avatar-generated">
+                  <image class="avatar-pattern" :src="defaultAvatarFor(u).uri" mode="aspectFill" />
+                  <text class="avatar-initial" :style="{ color: defaultAvatarFor(u).palette.text }">{{ avatarText(u.name) }}</text>
+                </view>
+              </view>
+              <text v-if="u.id===users.currentId" class="avatar-badge" :style="badgeStyle(u, 'active')">当前玩家</text>
+              <text v-else-if="idx === 0" class="avatar-badge" :style="badgeStyle(u, 'recent')">近期活跃</text>
+            </view>
+            <view class="text-block">
+              <view class="name-row">
+                <text class="name">{{ u.name }}</text>
+              </view>
+              <view class="meta-row">
+                <text class="meta-label">最近游玩</text>
+                <text class="meta-value">{{ lastPlayedText(u.lastPlayedAt) }}</text>
+              </view>
+              <text class="switch-hint" :style="{ color: defaultAvatarFor(u).palette.overlay }">点击左侧卡片即可切换至该角色</text>
+            </view>
+          </view>
+          <view class="ops">
+            <text class="ops-title">操作</text>
+            <view class="ops-buttons">
+              <button class="mini accent" :style="accentButtonStyle(u, 'primary')" @tap.stop="rename(u)">改名</button>
+              <button class="mini accent" :style="accentButtonStyle(u, 'secondary')" @tap.stop="changeAvatar(u)">头像</button>
+              <button class="mini danger" @tap.stop="remove(u.id)">删除</button>
+            </view>
+            <text class="ops-desc">删除后将移除该角色的历史统计</text>
+          </view>
         </view>
       </view>
     </view>
+
     <view
       v-if="hintState.visible"
       class="floating-hint-layer"
@@ -32,7 +81,6 @@
     </view>
   </view>
   <CustomTabBar />
-  
 </template>
 
 <script setup>
@@ -42,7 +90,7 @@ import CustomTabBar from '../../components/CustomTabBar.vue'
 import { ensureInit, getUsers, addUser, renameUser, removeUser as rmUser, switchUser } from '../../utils/store.js'
 import { useFloatingHint } from '../../utils/hints.js'
 import { useEdgeExit } from '../../utils/edge-exit.js'
-import { saveAvatarForUser, removeAvatarForUser, consumeAvatarRestoreNotice } from '../../utils/avatar.js'
+import { saveAvatarForUser, removeAvatarForUser, consumeAvatarRestoreNotice, generateDefaultAvatar } from '../../utils/avatar.js'
 import { exitApp } from '../../utils/navigation.js'
 
 const users = ref({ list: [], currentId: '' })
@@ -51,7 +99,9 @@ const newName = ref('')
 const { hintState, showHint, hideHint } = useFloatingHint()
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitPage() })
 
-// 过滤掉游客账号（名称为 Guest 的历史记录）
+const defaultAvatarCache = new Map()
+const FALLBACK_AVATAR = generateDefaultAvatar('tf24-default-user', { size: 120 })
+
 const visibleUsers = computed(() => (users.value.list || []).filter(u => String(u.name||'') !== 'Guest'))
 
 onMounted(() => { try { uni.hideTabBar && uni.hideTabBar() } catch (_) {}; ensureInit(); users.value = getUsers() })
@@ -62,6 +112,60 @@ onShow(() => {
     showHint('头像文件丢失，已为你恢复为默认头像', 2000)
   }
 })
+
+function defaultAvatarFor(user) {
+  if (!user) return FALLBACK_AVATAR
+  const key = `${user.id || ''}|${user.name || ''}|${user.color || ''}`
+  if (!defaultAvatarCache.has(key)) {
+    defaultAvatarCache.set(key, generateDefaultAvatar(key, { size: 120 }))
+  }
+  return defaultAvatarCache.get(key) || FALLBACK_AVATAR
+}
+
+function userCardStyle(user, index = 0) {
+  const theme = defaultAvatarFor(user)
+  const style = {
+    background: theme.panelGradient,
+    borderColor: theme.borderColor,
+    boxShadow: theme.shadow
+  }
+  if (users.value && users.value.currentId === user.id) {
+    style.borderColor = theme.palette.accent
+  }
+  if (index === 0) {
+    style.boxShadow = `0 32rpx 64rpx ${theme.softShadow}`
+  }
+  return style
+}
+
+function avatarRingStyle(user) {
+  const theme = defaultAvatarFor(user)
+  return {
+    borderColor: theme.borderColor,
+    boxShadow: `0 10rpx 22rpx ${theme.softShadow}`,
+    background: '#ffffff'
+  }
+}
+
+function badgeStyle(user, mode = 'active') {
+  const theme = defaultAvatarFor(user)
+  const gradient = mode === 'recent' ? theme.altBadgeGradient : theme.badgeGradient
+  return {
+    background: gradient,
+    color: theme.palette.badgeText,
+    boxShadow: `0 12rpx 24rpx ${theme.badgeShadow}`
+  }
+}
+
+function accentButtonStyle(user, mode = 'primary') {
+  const theme = defaultAvatarFor(user)
+  const gradient = mode === 'secondary' ? theme.altBadgeGradient : theme.badgeGradient
+  return {
+    background: gradient,
+    color: theme.palette.badgeText,
+    boxShadow: `0 12rpx 28rpx ${theme.badgeShadow}`
+  }
+}
 
 function refresh(){ users.value = getUsers() }
 function create(){ addUser(newName.value.trim()||undefined); newName.value=''; refresh() }
@@ -136,6 +240,22 @@ function avatarText(name){
   return s.length ? s[0].toUpperCase() : 'U'
 }
 
+function lastPlayedText(ts){
+  if (!ts) return '从未游玩'
+  try {
+    const d = new Date(ts)
+    const now = Date.now()
+    const dd = new Date()
+    const isToday = d.toDateString() === dd.toDateString()
+    const y = d.getFullYear(), m = (d.getMonth()+1).toString().padStart(2,'0'), day = d.getDate().toString().padStart(2,'0')
+    const hh = d.getHours().toString().padStart(2,'0'), mm = d.getMinutes().toString().padStart(2,'0')
+    if (isToday) return `今天 ${hh}:${mm}`
+    const yesterday = new Date(now - 86400000)
+    if (d.toDateString() === yesterday.toDateString()) return `昨天 ${hh}:${mm}`
+    return `${y}-${m}-${day} ${hh}:${mm}`
+  } catch(_) { return '时间未知' }
+}
+
 function exitPage(){
   exitApp({
     fallback: () => {
@@ -157,21 +277,333 @@ function exitPage(){
 </script>
 
 <style scoped>
-.input{ flex:1; border:2rpx solid #e5e7eb; border-radius:12rpx; padding:16rpx; background:#fff }
-.list{ display:flex; flex-direction:column; gap:12rpx }
-.item{ display:flex; justify-content:space-between; align-items:center; padding:16rpx; border-radius:16rpx; border:2rpx solid #e5e7eb; background:#fff; box-shadow:0 6rpx 16rpx rgba(15,23,42,0.06) }
-.item.active{ border-color:#1677ff55; box-shadow:0 6rpx 16rpx rgba(22, 119, 255, 0.12) }
-.user-left{ display:flex; align-items:center; gap:12rpx }
-.avatar{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#0f172a; }
-.avatar-img{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0 }
-.name{ font-size:32rpx; font-weight:700 }
-.ops{ display:flex; gap:8rpx }
-.mini{ padding:8rpx 12rpx; border-radius:10rpx; background:#eef2f7; font-size:24rpx }
-.mini.danger{ background:#fee2e2; color:#b91c1c }
-.btn-primary{ background:#1677ff; color:#fff; border:none; padding:18rpx 24rpx; border-radius:12rpx }
-.page{ min-height:100vh; box-sizing:border-box; position:relative; }
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-</style>
+.page {
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 32rpx 32rpx 120rpx 32rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 45%, #f1f5f9 100%);
+  position: relative;
+}
+.management-hero {
+  background: linear-gradient(135deg, rgba(59,130,246,0.12), rgba(14,165,233,0.08));
+  border: 2rpx solid rgba(148,163,184,0.35);
+  border-radius: 28rpx;
+  padding: 28rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+.hero-title {
+  font-size: 40rpx;
+  font-weight: 900;
+  color: #0f172a;
+}
+.hero-sub {
+  font-size: 26rpx;
+  color: #475569;
+}
+.hero-note {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+  font-size: 24rpx;
+  color: #475569;
+}
+.hero-tag {
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 999rpx;
+  padding: 4rpx 18rpx;
+  font-size: 22rpx;
+}
+.create-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+  border-radius: 28rpx;
+  border: 2rpx solid rgba(148,163,184,0.25);
+  background: rgba(255,255,255,0.85);
+  padding: 28rpx;
+}
+.create-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+.create-title {
+  font-size: 32rpx;
+  font-weight: 800;
+  color: #0f172a;
+}
+.create-hint {
+  font-size: 24rpx;
+  color: #64748b;
+}
+.create-row {
+  display: flex;
+  gap: 16rpx;
+  align-items: center;
+}
+.input {
+  flex: 1;
+  border: 2rpx solid #e5e7eb;
+  border-radius: 16rpx;
+  padding: 18rpx 20rpx;
+  background: #fff;
+  font-size: 28rpx;
+}
+.btn-primary {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  color: #fff;
+  border: none;
+  padding: 18rpx 32rpx;
+  border-radius: 16rpx;
+  font-weight: 700;
+}
+.list-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+  border-radius: 32rpx;
+  border: 2rpx solid rgba(148,163,184,0.3);
+  background: rgba(255,255,255,0.9);
+  padding: 28rpx;
+  min-height: 0;
+}
+.list-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+.list-title {
+  font-size: 34rpx;
+  font-weight: 800;
+  color: #0f172a;
+}
+.list-sub {
+  font-size: 24rpx;
+  color: #475569;
+}
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+  overflow-y: auto;
+  padding-right: 6rpx;
+}
+.list::-webkit-scrollbar {
+  width: 6rpx;
+}
+.list::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3rpx;
+}
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+  border-radius: 28rpx;
+  border: 2rpx solid transparent;
+  padding: 22rpx;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.item.active {
+  border-color: rgba(37,99,235,0.55);
+}
+.item:active {
+  transform: scale(0.98);
+}
+.item-left {
+  display: flex;
+  gap: 20rpx;
+  align-items: center;
+}
+.avatar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10rpx;
+}
+.avatar-ring {
+  width: 92rpx;
+  height: 92rpx;
+  border-radius: 50%;
+  border: 4rpx solid rgba(255,255,255,0.6);
+  padding: 8rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.avatar-img,
+.avatar-generated {
+  width: 76rpx;
+  height: 76rpx;
+  border-radius: 50%;
+  overflow: hidden;
+  position: relative;
+}
+.avatar-generated {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.avatar-pattern {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.avatar-initial {
+  font-weight: 800;
+  font-size: 30rpx;
+  z-index: 1;
+}
+.avatar-badge {
+  font-size: 22rpx;
+  padding: 4rpx 18rpx;
+  border-radius: 999rpx;
+  font-weight: 700;
+  color: #fff;
+}
+.text-block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10rpx;
+  min-width: 0;
+}
+.name-row {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+}
+.name {
+  font-size: 34rpx;
+  font-weight: 800;
+  color: #0f172a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+  font-size: 24rpx;
+  color: #475569;
+}
+.meta-label {
+  font-weight: 600;
+  opacity: 0.7;
+}
+.meta-value {
+  font-weight: 600;
+}
+.switch-hint {
+  font-size: 22rpx;
+  color: #64748b;
+}
+.ops {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  background: rgba(255,255,255,0.6);
+  border-radius: 24rpx;
+  border: 2rpx solid rgba(148,163,184,0.25);
+  padding: 16rpx;
+}
+.ops-title {
+  font-size: 24rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+.ops-buttons {
+  display: flex;
+  gap: 12rpx;
+}
+.mini {
+  padding: 10rpx 22rpx;
+  border-radius: 14rpx;
+  font-size: 24rpx;
+  border: none;
+}
+.mini.accent {
+  color: #fff;
+}
+.mini.danger {
+  background: linear-gradient(135deg, #f97316, #ef4444);
+  color: #fff;
+  box-shadow: 0 12rpx 24rpx rgba(239,68,68,0.3);
+}
+.ops-desc {
+  font-size: 22rpx;
+  color: #64748b;
+}
+.floating-hint-layer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 999;
+}
+.floating-hint-layer.interactive {
+  pointer-events: auto;
+}
+.floating-hint {
+  max-width: 70%;
+  background: rgba(15,23,42,0.86);
+  color: #fff;
+  padding: 24rpx 36rpx;
+  border-radius: 24rpx;
+  text-align: center;
+  font-size: 30rpx;
+  box-shadow: 0 20rpx 48rpx rgba(15,23,42,0.25);
+  backdrop-filter: blur(12px);
+}
 
+@media screen and (min-width: 900px) {
+  .page {
+    padding: 40rpx 80rpx 140rpx 80rpx;
+  }
+  .item {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .ops {
+    width: 320rpx;
+    align-self: stretch;
+    justify-content: center;
+  }
+  .ops-buttons {
+    flex-wrap: wrap;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .create-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .btn-primary {
+    width: 100%;
+  }
+  .item-left {
+    align-items: flex-start;
+  }
+  .ops {
+    align-self: stretch;
+  }
+  .ops-buttons {
+    flex-wrap: wrap;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add colourful cards, badges, and responsive layout tweaks to the login experience
- generate neutral default avatar SVGs that provide geometric backgrounds and palette metadata
- restyle the user management list with card backgrounds, descriptive labels, and prominent action buttons

## Testing
- not run (uni-app project without automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68cfaec736ec83239b884452c8020267