### PR TITLE
feat(stats): refresh stats UI with rank tiers

### DIFF
--- a/styles/common.css
+++ b/styles/common.css
@@ -8,13 +8,34 @@
 .btn-ghost { background:transparent; color:#145751; border:2rpx solid #145751 }
 
 /* 表格型网格容器（统计页通用） */
-.grid-table { border-radius:12rpx; overflow:hidden; border:1rpx solid #e5e7eb }
-.grid-table .thead, .grid-table .tbody { display:grid; align-items:center; grid-gap:6rpx; min-height:44rpx }
-.grid-table .thead { color:#6b7280; font-weight:700; padding:8rpx 12rpx; background:#f8fafc; font-size:24rpx }
-.grid-table .tr { padding:10rpx 12rpx; border-top:1rpx solid #f1f5f9; font-size:26rpx }
-.grid-table .td, .grid-table .th { text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; line-height:1.4 }
-.ok { color:#16a34a; font-weight:700 }
-.fail { color:#dc2626; font-weight:700 }
+.grid-table { position:relative; border-radius:20rpx; overflow:hidden; border:1rpx solid rgba(148,163,184,0.25); background:rgba(15,23,42,0.55); backdrop-filter:blur(12rpx) }
+.grid-table .thead, .grid-table .tr { display:grid; align-items:center; grid-gap:12rpx }
+.grid-table .thead { color:#cbd5f5; font-weight:700; padding:12rpx 16rpx; background:rgba(15,23,42,0.82); font-size:24rpx; letter-spacing:2rpx }
+.grid-table .tr { padding:16rpx; border-top:1rpx solid rgba(148,163,184,0.15); font-size:26rpx; background:rgba(15,23,42,0.45); transition:background 0.2s ease }
+.grid-table .tr:nth-child(even) { background:rgba(15,23,42,0.38) }
+.grid-table .tr:active { background:rgba(59,130,246,0.24) }
+.grid-table .td, .grid-table .th { text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; line-height:1.4; color:#e2e8f0 }
+.grid-table .th.active { color:#facc15 }
+.ok { color:#34d399; font-weight:700 }
+.fail { color:#f87171; font-weight:700 }
+
+/* 胜率条/错题徽章等工具类 */
+.stacked-bar { display:flex; width:100%; height:18rpx; background:rgba(148,163,184,0.25); border-radius:9999rpx; overflow:hidden }
+.stacked-bar.small { height:14rpx }
+.stacked-bar.big { height:22rpx }
+.stacked-bar .seg { height:100% }
+.stacked-bar .seg.win { background:linear-gradient(90deg,#16a34a,#34d399) }
+.stacked-bar .seg.fail { background:linear-gradient(90deg,#f43f5e,#ef4444) }
+.stacked-bar .seg.rank { background:linear-gradient(90deg,#38bdf8,#818cf8) }
+.stacked-bar .seg.warn { background:#facc15 }
+.stacked-bar .seg.calm { background:#22d3ee }
+
+.text-win { color:#34d399; font-weight:700 }
+.text-fail { color:#f87171; font-weight:700 }
+.text-accent { color:#38bdf8; font-weight:700 }
+.text-warn { color:#facc15; font-weight:700 }
+.text-calm { color:#22d3ee; font-weight:700 }
+.text-muted { color:#94a3b8 }
 
 /* 迷你图形：条形与微火柴的基础样式 */
 .bar-track { position:relative; height:14rpx; background:#e5e7eb; border-radius:9999rpx; overflow:hidden }


### PR DESCRIPTION
## Summary
- restyle the stats overview with card backgrounds, segmented progress bars, and reordered highlights for win rate and streaks
- add reusable stacked-bar utilities and color tokens for percentage chips and badges
- derive rank tiers from win rate or streak data and surface the tier in the overview and detail panels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfaec863bc8323b526e636ff62808b