### PR TITLE
feat: refresh stats and stabilize game footer

### DIFF
--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -2,69 +2,73 @@
   <view
     class="page col"
     :class="{ booted }"
-    style="padding: 24rpx; position: relative;"
+    style="position: relative;"
     @touchstart="edgeHandlers.handleTouchStart"
     @touchmove="edgeHandlers.handleTouchMove"
     @touchend="edgeHandlers.handleTouchEnd"
     @touchcancel="edgeHandlers.handleTouchCancel"
   >
 
-    <view class="game-content">
+    <view class="game-shell">
+      <view class="game-header">
 
-    <!-- 顶部：当前用户 -->
-    <view class="topbar">
-      <view class="user-chip" hover-class="user-chip-hover" @tap="goLogin">
-        <template v-if="currentUserAvatar && !avatarLoadFailed">
-          <image class="user-chip-avatar" :src="currentUserAvatar" mode="aspectFill" @error="onAvatarError" />
-        </template>
-        <view v-else class="user-chip-fallback" :style="{ backgroundColor: currentUserColor }">{{ currentUserInitial }}</view>
-        <text class="user-chip-name">{{ currentUserName }}</text>
-      </view>
-    </view>
-
-    <view class="mode-bar">
-      <button
-        class="btn mode-toggle-btn"
-        :class="mode === 'pro' ? 'mode-toggle-pro' : 'mode-toggle-basic'"
-        @click="toggleMode"
-      >{{ modeButtonLabel }}</button>
-      <view style="flex:1;">
-        <button
-          class="btn btn-secondary deck-toggle-btn"
-          @click="toggleDeckSource"
-        >{{ deckSourceLabel }}</button>
-      </view>
-    </view>
-
-    <!-- 本局统计：紧凑表格（1行表头 + 1行数据） -->
-      <view id="statsRow" class="card section stats-compact-table stats-card">
-        <view class="thead">
-        <text class="th">剩余</text>
-        <text class="th">局数</text>
-        <text class="th ok">成功</text>
-        <text class="th fail">失败</text>
-        <text class="th">胜率</text>
-        <text class="th">上一局</text>
-        <text class="th">本局</text>
+        <!-- 顶部：当前用户 -->
+        <view class="topbar">
+          <view class="user-chip" hover-class="user-chip-hover" @tap="goLogin">
+            <template v-if="currentUserAvatar && !avatarLoadFailed">
+              <image class="user-chip-avatar" :src="currentUserAvatar" mode="aspectFill" @error="onAvatarError" />
+            </template>
+            <view v-else class="user-chip-fallback" :style="{ backgroundColor: currentUserColor }">{{ currentUserInitial }}</view>
+            <text class="user-chip-name">{{ currentUserName }}</text>
+          </view>
         </view>
-      <view class="tbody">
-        <text class="td">{{ remainingCards }}</text>
-        <text class="td">{{ handsPlayed }}</text>
-        <text class="td ok">{{ successCount }}</text>
-        <text class="td fail">{{ failCount }}</text>
-        <text class="td">{{ winRate }}%</text>
-        <text class="td">{{ lastSuccessMs != null ? fmtMs(lastSuccessMs) : '-' }}</text>
-        <view class="td timer-cell" id="timerCell" @tap="handleTimerTap">
-          <block v-if="handElapsedMs < 120000">
-            <text>{{ fmtMs1(handElapsedMs) }}</text>
-          </block>
-          <block v-else>
-            <button class="btn btn-secondary btn-reshuffle" @click.stop="reshuffle">洗牌</button>
-          </block>
+
+        <view class="mode-bar">
+          <button
+            class="btn mode-toggle-btn"
+            :class="mode === 'pro' ? 'mode-toggle-pro' : 'mode-toggle-basic'"
+            @click="toggleMode"
+          >{{ modeButtonLabel }}</button>
+          <view style="flex:1;">
+            <button
+              class="btn btn-secondary deck-toggle-btn"
+              @click="toggleDeckSource"
+            >{{ deckSourceLabel }}</button>
+          </view>
+        </view>
+
+        <!-- 本局统计：紧凑表格（1行表头 + 1行数据） -->
+        <view id="statsRow" class="card section stats-compact-table stats-card">
+          <view class="thead">
+            <text class="th">剩余</text>
+            <text class="th">局数</text>
+            <text class="th ok">成功</text>
+            <text class="th fail">失败</text>
+            <text class="th">胜率</text>
+            <text class="th">上一局</text>
+            <text class="th">本局</text>
+          </view>
+          <view class="tbody">
+            <text class="td">{{ remainingCards }}</text>
+            <text class="td">{{ handsPlayed }}</text>
+            <text class="td ok">{{ successCount }}</text>
+            <text class="td fail">{{ failCount }}</text>
+            <text class="td">{{ winRate }}%</text>
+            <text class="td">{{ lastSuccessMs != null ? fmtMs(lastSuccessMs) : '-' }}</text>
+            <view class="td timer-cell" id="timerCell" @tap="handleTimerTap">
+              <block v-if="handElapsedMs < 120000">
+                <text>{{ fmtMs1(handElapsedMs) }}</text>
+              </block>
+              <block v-else>
+                <button class="btn btn-secondary btn-reshuffle" @click.stop="reshuffle">洗牌</button>
+              </block>
+            </view>
+          </view>
         </view>
       </view>
-    </view>
-    <view class="mode-panels">
+
+      <view class="game-main">
+        <view class="mode-panels">
       <view class="pro-mode mode-panel" v-show="mode === 'pro'">
         <!-- 牌区：四张卡片等宽占满一行（每张卡片单独计数） -->
         <view id="cardGrid" class="card-grid" style="padding-top: 0rpx;">
@@ -151,11 +155,8 @@
           </view>
         </view>
       </view>
-    </view>
 
-    </view>
-
-    <view class="game-footer">
+      <view class="game-footer">
       <view id="submitRow" class="footer-row">
         <button v-show="mode === 'pro'" class="btn btn-primary footer-primary-btn" @click="check">提交答案</button>
         <view v-show="mode !== 'pro'" class="basic-utility-grid">
@@ -173,6 +174,8 @@
           <button class="btn btn-secondary" @click="skipHand">下一题</button>
         </view>
       </view>
+    </view>
+
     </view>
 
     <!-- 底部导航由全局 tabBar 提供（见 pages.json） -->
@@ -1463,10 +1466,27 @@ function onSessionOver() {
 </script>
 
 <style scoped> 
-.page { min-height: 100dvh; min-height: calc(var(--vh, 1vh) * 100); background: #f8fafc; display:flex; flex-direction: column; } 
-.page { opacity: 0; } 
-.page.booted { animation: page-fade-in .28s ease-out forwards; } 
-.game-content { flex:1; display:flex; flex-direction:column; gap:16rpx; }
+.page {
+  min-height: 100dvh;
+  min-height: calc(var(--vh, 1vh) * 100);
+  background: #f8fafc;
+  display:flex;
+  flex-direction: column;
+  box-sizing:border-box;
+  padding:24rpx;
+  padding-bottom: calc(24rpx + env(safe-area-inset-bottom) + var(--tf24-tabbar-height, 120rpx) + (var(--tf24-footer-row-height, 120rpx) * 2) + var(--tf24-footer-gap, 16rpx));
+}
+.page { opacity: 0; }
+.page.booted { animation: page-fade-in .28s ease-out forwards; }
+.game-shell {
+  flex:1;
+  min-height:100%;
+  display:grid;
+  grid-template-rows:auto 1fr auto;
+  gap:24rpx;
+}
+.game-header { display:flex; flex-direction:column; gap:16rpx; }
+.game-main { display:flex; flex-direction:column; min-height:400rpx; }
 .mode-panels { flex:1; display:flex; flex-direction:column; gap:18rpx; }
 .mode-panel { display:flex; flex-direction:column; gap:18rpx; }
 .pro-mode { flex:1; }
@@ -1540,11 +1560,17 @@ function onSessionOver() {
 }
 
 .game-footer {
-  margin-top:auto;
+  position:sticky;
+  bottom: calc(var(--tf24-tabbar-height, 120rpx) + env(safe-area-inset-bottom));
+  z-index:20;
   display:flex;
   flex-direction:column;
   gap:var(--tf24-footer-gap, 16rpx);
-  padding-top:12rpx;
+  padding:12rpx 0;
+  background: var(--tf24-footer-bg, #f8fafc);
+  box-shadow:0 -8rpx 20rpx rgba(15,23,42,0.12);
+  border-radius:24rpx;
+  min-height: var(--tf24-footer-total, calc(var(--tf24-footer-row-height, 120rpx) * 2 + var(--tf24-footer-gap, 16rpx)));
 }
 .footer-row {
   display:flex;

--- a/pages/stats/index.vue
+++ b/pages/stats/index.vue
@@ -169,20 +169,20 @@
         </label>
       </view>
       <view class="table mistake-table" v-if="mistakeDisplayRows.length">
-        <view class="thead" :style="{ display:'grid', gridTemplateColumns:'260rpx 140rpx 140rpx 140rpx 140rpx' }">
-          <text class="th" style="text-align:left;">题目 key</text>
-          <text class="th">尝试</text>
-          <text class="th fail">错</text>
-          <text class="th ok">对</text>
-          <text class="th">活动</text>
+        <view class="mistake-grid mistake-head">
+          <text class="mistake-th key">题目 key</text>
+          <text class="mistake-th">尝试</text>
+          <text class="mistake-th">错误</text>
+          <text class="mistake-th">正确</text>
+          <text class="mistake-th">是否活动</text>
         </view>
-        <view class="tbody">
-          <view class="tr" v-for="row in mistakeDisplayRows" :key="row.key" :style="{ display:'grid', gridTemplateColumns:'260rpx 140rpx 140rpx 140rpx 140rpx' }">
-            <text class="td mistake-key" style="text-align:left;" @tap="copyMistakeKey(row)">{{ row.displayKey }}</text>
-            <text class="td">{{ row.attempts }}</text>
-            <text class="td fail">{{ row.wrong }}</text>
-            <text class="td ok">{{ row.correct }}</text>
-            <text class="td" :class="{ ok: row.active }">{{ row.active ? '是' : '否' }}</text>
+        <view class="mistake-body">
+          <view class="mistake-grid mistake-row" v-for="row in mistakeDisplayRows" :key="row.key">
+            <text class="mistake-cell key" @tap="copyMistakeKey(row)">{{ row.displayKey }}</text>
+            <text class="mistake-cell">{{ row.attempts }}</text>
+            <text class="mistake-cell fail">{{ row.wrong }}</text>
+            <text class="mistake-cell ok">{{ row.correct }}</text>
+            <text class="mistake-cell" :class="{ ok: row.active }">{{ row.active ? '是' : '否' }}</text>
           </view>
         </view>
       </view>
@@ -1037,10 +1037,16 @@ function exitStatsPage() {
   transform-origin: center center;  /* 旋转参考点，可以根据需求改为 left bottom 等 */
   white-space: nowrap;
 }
-.rounds{ margin-top:12rpx; display:flex; flex-direction:column; row-gap:16rpx }
+.rounds{
+  margin-top:12rpx;
+  display:flex;
+  flex-direction:column;
+  row-gap:16rpx;
+  --recent-rounds-grid: 200rpx 120rpx 160rpx 1fr;
+}
 .rounds-head{
   display:grid;
-  grid-template-columns: 200rpx 120rpx 160rpx 1fr;
+  grid-template-columns: var(--recent-rounds-grid);
   gap:8rpx;
   padding:8rpx 4rpx;
   background: var(--tf24-table-head-bg, #f8fafc);
@@ -1049,16 +1055,23 @@ function exitStatsPage() {
   font-weight:700;
   border-radius:12rpx;
 }
-.rounds-head text{
+.rounds-head text,
+.round-item text{
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
 }
-.rounds-head text:nth-child(2),
-.rounds-head text:nth-child(3){ text-align:center; }
-.rounds-head text:first-child,
-.rounds-head text:last-child{ text-align:left; }
-.round-item{ display:grid; grid-template-columns: 200rpx 120rpx 160rpx 1fr; grid-gap:8rpx; padding:8rpx 4rpx; border-top:2rpx solid #eef2f7 }
+.round-item{
+  display:grid;
+  grid-template-columns: var(--recent-rounds-grid);
+  grid-gap:8rpx;
+  padding:8rpx 4rpx;
+  border-top:2rpx solid #eef2f7;
+}
 .r-time, .r-result, .r-timeMs {
   font-size: 26rpx;
   font-weight: 600;
@@ -1093,14 +1106,38 @@ function exitStatsPage() {
 .mistake-summary-value{ color:#111827; font-size:36rpx; font-weight:700; }
 .mistake-controls{ display:flex; align-items:center; justify-content:flex-start; gap:16rpx; margin-top:16rpx; flex-wrap:wrap; }
 .mistake-filter{ display:flex; align-items:center; gap:12rpx; color:#374151; font-size:26rpx; }
-.mistake-table .td{ text-align:center; }
-.mistake-table .td:first-child{ text-align:left; }
-.mistake-tip{ color:#6b7280; font-size:24rpx; flex:1; text-align:right; }
-.mistake-key{
+.mistake-table{ max-width:100%; overflow:hidden; }
+.mistake-grid{
+  display:grid;
+  grid-template-columns: minmax(200rpx, 1.6fr) repeat(4, minmax(120rpx, 1fr));
+  width:100%;
+}
+.mistake-head{
+  background: var(--tf24-table-head-bg, #f8fafc);
+  color: var(--tf24-table-head-color, #475569);
+  font-weight:700;
+  font-size:24rpx;
+}
+.mistake-body{ display:flex; flex-direction:column; width:100%; }
+.mistake-row{ border-top:1rpx solid #f1f5f9; font-size:26rpx; }
+.mistake-grid text{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:10rpx 8rpx;
+  text-align:center;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.mistake-grid .mistake-th{ padding:12rpx 8rpx; }
+.mistake-cell.key,
+.mistake-th.key{
   font-family: 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
   color:#0f172a;
 }
-.mistake-key:active{ opacity:.7; }
+.mistake-cell.key:active{ opacity:.7; }
+.mistake-tip{ color:#6b7280; font-size:24rpx; flex:1; text-align:right; }
 .mistake-empty{ color:#64748b; font-size:26rpx; margin-top:8rpx; }
 .empty-tip{ color:#64748b; font-size:26rpx; margin-top:8rpx; }
 

--- a/styles/common.css
+++ b/styles/common.css
@@ -4,6 +4,9 @@
   --tf24-table-head-color: #334155;
   --tf24-footer-row-height: 120rpx;
   --tf24-footer-gap: 16rpx;
+  --tf24-footer-bg: #f8fafc;
+  --tf24-tabbar-height: 120rpx;
+  --tf24-footer-total: calc(var(--tf24-footer-row-height, 120rpx) * 2 + var(--tf24-footer-gap, 16rpx));
 }
 
 /* 通用卡片与标题 */

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,3 +1,11 @@
+/* 主题变量 */
+:root {
+  --tf24-table-head-bg: #f8fafc;
+  --tf24-table-head-color: #334155;
+  --tf24-footer-row-height: 120rpx;
+  --tf24-footer-gap: 16rpx;
+}
+
 /* 通用卡片与标题 */
 .card { background:#fff; border:2rpx solid #e5e7eb; border-radius:16rpx; box-shadow:0 6rpx 16rpx rgba(15,23,42,.06) }
 .section { padding:16rpx }


### PR DESCRIPTION
## Summary
- add a header row and empty state to recent rounds, and simplify the mistake book to default to active items with copy support
- remove unused stats panels and introduce shared theme variables for tables and footers
- show a clickable avatar + username chip on the game page and keep the shared footer layout stable across modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfed69f13483238fdfed80d7f7dff3