### PR TITLE
feat: apply claymorphism theme across pages

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -19,10 +19,7 @@ export default {
 </script>
 
 <style>
-/* 全局样式可放在 uni.scss 中 */
-page {
-  background-color: #f8f8f8;
-}
+@import "@/common/theme.css";
 
 /* uni-h5 旧版头部兜底隐藏（仅当 navigationStyle 未生效时） */
 .uni-page-head,

--- a/common/theme.css
+++ b/common/theme.css
@@ -1,0 +1,79 @@
+/* Claymorphism theme tokens and utility classes */
+:root, page {
+  --bg-light: #F0F4F8;
+  --bg-dark: #A9B4C2;
+  --surface-light: #E6ECF2;
+  --surface-dark: #C2CAD6;
+  --primary: #98D2EB;
+  --primary-dark: #64A2C5;
+  --text-light: #5C6A79;
+  --text-dark: #434E5A;
+  --accent1: #F9C897;
+  --accent2: #A8E6CF;
+}
+
+page {
+  background-color: var(--bg-light);
+  color: var(--text-light);
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "PingFang SC", "Microsoft Yahei";
+}
+
+.page { display:flex; flex-direction:column; min-height:100vh; }
+.row { display:flex; flex-direction:row; }
+.col { display:flex; flex-direction:column; }
+.center { align-items:center; justify-content:center; }
+
+.claymorphism{
+  border-radius: 30rpx;
+  background: var(--surface-light);
+  box-shadow: 8rpx 8rpx 16rpx var(--bg-dark), -8rpx -8rpx 16rpx #ffffff;
+}
+.claymorphism-inset{
+  border-radius: 20rpx;
+  background: var(--bg-light);
+  box-shadow: inset 6rpx 6rpx 12rpx var(--bg-dark), inset -6rpx -6rpx 12rpx #ffffff;
+}
+
+.clay-button{
+  border-radius: 20rpx;
+  background: var(--surface-light);
+  color: var(--text-light);
+  box-shadow: 6rpx 6rpx 12rpx var(--bg-dark), -6rpx -6rpx 12rpx #ffffff;
+  transition: all .2s ease-in-out;
+}
+.clay-button:active{
+  box-shadow: inset 4rpx 4rpx 8rpx var(--bg-dark), inset -4rpx -4rpx 8rpx #ffffff;
+}
+.clay-button-primary{
+  border-radius: 20rpx;
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 6rpx 6rpx 12rpx var(--primary-dark), -6rpx -6rpx 12rpx #c4eaff;
+}
+.clay-button-primary:active{
+  box-shadow: inset 4rpx 4rpx 8rpx var(--primary-dark), inset -4rpx -4rpx 8rpx #c4eaff;
+}
+
+.text-shadow-strong{
+  text-shadow: 2rpx 2rpx 0 var(--primary-dark), 4rpx 4rpx 0 var(--bg-dark);
+}
+.card { padding: 24rpx; }
+.gap16 > * + * { margin-top: 16rpx; }
+.gap24 > * + * { margin-top: 24rpx; }
+.grid2 { display:grid; grid-template-columns: 1fr 1fr; grid-gap: 16rpx; }
+.grid4 { display:grid; grid-template-columns: repeat(4, 1fr); grid-gap: 16rpx; }
+.h56 { height: 56rpx; }
+.h96 { height: 96rpx; }
+.h120{ height: 120rpx; }
+.text-xs{ font-size: 22rpx; }
+.text-sm{ font-size: 26rpx; }
+.text-lg{ font-size: 32rpx; }
+.text-2xl{ font-size: 40rpx; }
+.text-3xl{ font-size: 48rpx; }
+.text-4xl{ font-size: 56rpx; }
+.text-5xl{ font-size: 64rpx; }
+.text-6xl{ font-size: 72rpx; }
+.rounded-full{ border-radius: 9999rpx; }
+.opacity-50{ opacity: .5; }
+.bold{ font-weight: 700; }

--- a/components/ActionBar.vue
+++ b/components/ActionBar.vue
@@ -1,0 +1,14 @@
+<template>
+  <view class="grid2">
+    <button class="clay-button" style="padding:24rpx;" @tap="$emit('undo')">
+      <text class="text-lg bold">Undo</text>
+    </button>
+    <button class="clay-button-primary" style="padding:24rpx;" @tap="$emit('submit')">
+      <text class="text-lg bold" style="color:#fff;">Submit</text>
+    </button>
+  </view>
+</template>
+
+<script>
+export default { name:'ActionBar' }
+</script>

--- a/components/BigNumber.vue
+++ b/components/BigNumber.vue
@@ -1,0 +1,21 @@
+<template>
+  <view class="claymorphism card" style="margin-bottom:24rpx; align-items:center;">
+    <text class="text-6xl text-shadow-strong" style="color:#fff; font-weight:800; margin-bottom:16rpx;">{{ number }}</text>
+    <view class="claymorphism-inset" style="width:100%; height:16rpx; border-radius:9999rpx; background:var(--surface-dark);">
+      <view :style="barStyle"></view>
+    </view>
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'BigNumber',
+  props: { number: {type:[String,Number], default: 18}, progress: {type:Number, default: 0.75} },
+  computed:{
+    barStyle(){
+      const p = Math.max(0, Math.min(1, this.progress))*100 + '%'
+      return `width:${p}; height:100%; background:var(--accent2); border-radius:9999rpx;`
+    }
+  }
+}
+</script>

--- a/components/BottomTab.vue
+++ b/components/BottomTab.vue
@@ -1,0 +1,159 @@
+<template>
+  <view class="bottom-tab" :style="wrapStyle">
+    <view class="claymorphism row" style="justify-content:space-around; align-items:center; padding:16rpx; gap:16rpx;">
+      <view class="tab-item" :class="{ active: isActive('stats') }" @tap="go('/pages/stats/index')">
+        <text class="tab-icon">📊</text>
+        <text class="tab-text">统计</text>
+      </view>
+      <view class="tab-item" :class="{ active: isActive('index') }" @tap="go('/pages/index/index')">
+        <text class="tab-icon">🎮</text>
+        <text class="tab-text">程序</text>
+      </view>
+      <view class="tab-item" :class="{ active: isActive('user') }" @tap="go('/pages/user/index')">
+        <text class="tab-icon">👤</text>
+        <text class="tab-text">用户</text>
+      </view>
+    </view>
+    <view class="tab-safe" />
+  </view>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const currentPath = ref('')
+const wrapStyle = ref('')
+
+onMounted(() => {
+  try { uni.hideTabBar && uni.hideTabBar() } catch (_) {}
+  updatePath()
+  try {
+    const sys = uni.getSystemInfoSync && uni.getSystemInfoSync()
+    const hb = (sys && sys.safeAreaInsets && sys.safeAreaInsets.bottom) || 0
+    wrapStyle.value = `padding-bottom:${hb ? hb + 'px' : 'env(safe-area-inset-bottom)'}`
+  } catch (_) {}
+  try { uni.$off && uni.$off('tabbar:update', updatePath) } catch(_) {}
+  try { uni.$on && uni.$on('tabbar:update', updatePath) } catch(_) {}
+})
+
+onUnmounted(() => { try { uni.$off && uni.$off('tabbar:update', updatePath) } catch(_) {} })
+
+function updatePath(){
+  try {
+    const pages = getCurrentPages && getCurrentPages()
+    const cur = pages && pages[pages.length - 1]
+    currentPath.value = (cur && (cur.route || cur.$page?.fullPath || '')) || ''
+  } catch (_) { currentPath.value = '' }
+}
+
+function isActive(key){
+  const p = currentPath.value
+  if (!p) return false
+  if (key === 'stats') return p.includes('pages/stats/index')
+  if (key === 'index') return p.includes('pages/index/index')
+  if (key === 'user') return p.includes('pages/user/index')
+  return false
+}
+
+function normalizePath(u){
+  if (!u) return ''
+  const s = String(u)
+  const withSlash = s.startsWith('/') ? s : ('/' + s)
+  return withSlash.split(/[?#]/)[0].replace(/\/+/g, '/')
+}
+
+function currentRoutePath(){
+  try {
+    const pages = getCurrentPages && getCurrentPages()
+    const cur = pages && pages[pages.length - 1]
+    const r = (cur && (cur.route || cur.$page?.fullPath || '')) || ''
+    return normalizePath(r)
+  } catch(_) { return '' }
+}
+
+function go(url){
+  const now = currentRoutePath()
+  const target = normalizePath(url)
+  if (now && target && now === target) return
+
+  const done = () => { try { updatePath() } catch(_) {} }
+
+  if (uni && typeof uni.switchTab === 'function') {
+    uni.switchTab({
+      url,
+      success: done,
+      fail() {
+        if (typeof uni.navigateTo === 'function') {
+          uni.navigateTo({
+            url,
+            success: done,
+            fail() {
+              if (typeof uni.reLaunch === 'function') {
+                uni.reLaunch({ url, success: done, fail: done })
+              } else { done() }
+            }
+          })
+        } else if (typeof uni.reLaunch === 'function') {
+          uni.reLaunch({ url, success: done, fail: done })
+        } else { done() }
+      }
+    })
+    return
+  }
+
+  if (typeof uni.navigateTo === 'function') {
+    uni.navigateTo({
+      url,
+      success: done,
+      fail() {
+        if (typeof uni.reLaunch === 'function') {
+          uni.reLaunch({ url, success: done, fail: done })
+        } else { done() }
+      }
+    })
+  } else if (typeof uni.reLaunch === 'function') {
+    uni.reLaunch({ url, success: done, fail: done })
+  }
+}
+</script>
+
+<style scoped>
+.bottom-tab {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.tab-safe { height: env(safe-area-inset-bottom); }
+
+.tab-item {
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:8rpx;
+  padding:12rpx 24rpx;
+  border-radius:24rpx;
+  transition: all .2s ease-in-out;
+  color: var(--text-dark);
+}
+
+.tab-item.active {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 6rpx 6rpx 12rpx var(--primary-dark), -6rpx -6rpx 12rpx #c4eaff;
+}
+
+.tab-item:active {
+  box-shadow: inset 4rpx 4rpx 8rpx var(--bg-dark), inset -4rpx -4rpx 8rpx #ffffff;
+}
+
+.tab-icon { font-size: 36rpx; }
+.tab-text { font-size: 24rpx; font-weight: 700; }
+</style>

--- a/components/CardGrid.vue
+++ b/components/CardGrid.vue
@@ -1,0 +1,19 @@
+<template>
+  <view class="grid4" style="margin-bottom:24rpx;">
+    <view v-for="(item,idx) in items" :key="idx"
+          class="clay-button center h120"
+          :class="[{ 'opacity-50': item.disabled }]"
+          @tap="$emit('tap-item', item)">
+      <text class="text-5xl" style="color:var(--text-dark);">{{ item.label }}</text>
+    </view>
+  </view>
+</template>
+
+<script>
+export default {
+  name:'CardGrid',
+  props:{ items:{ type:Array, default:()=>[
+    {label:'8'},{label:'Q',disabled:true},{label:'6'},{label:'8',disabled:true}
+  ]}}
+}
+</script>

--- a/components/OpPad.vue
+++ b/components/OpPad.vue
@@ -1,0 +1,14 @@
+<template>
+  <view class="grid4" style="margin-bottom:32rpx;">
+    <button v-for="(op,i) in ops" :key="i" class="clay-button center" style="height:96rpx;" @tap="$emit('tap-op', op)">
+      <text :class="[op.length>1?'text-3xl':'text-4xl']" style="font-weight:700;">{{ op }}</text>
+    </button>
+  </view>
+</template>
+
+<script>
+export default {
+  name:'OpPad',
+  props:{ ops:{ type:Array, default:()=>['+','-','×','÷'] } }
+}
+</script>

--- a/components/StatsGrid.vue
+++ b/components/StatsGrid.vue
@@ -1,0 +1,21 @@
+<template>
+  <view class="claymorphism-inset card" style="margin-bottom:24rpx;">
+    <view class="grid2">
+      <view class="claymorphism card" style="text-align:center;">
+        <text class="text-sm bold">Score</text>
+        <text class="text-3xl" style="color:var(--primary-dark); display:block;">{{ score }}</text>
+      </view>
+      <view class="claymorphism card" style="text-align:center;">
+        <text class="text-sm bold">Time</text>
+        <text class="text-3xl" style="color:var(--text-dark); display:block;">{{ time }}</text>
+      </view>
+    </view>
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'StatsGrid',
+  props: { score: {type:[String,Number],default:1250}, time: {type:String, default:'12:34'} }
+}
+</script>

--- a/components/UIHeader.vue
+++ b/components/UIHeader.vue
@@ -1,0 +1,36 @@
+<template>
+  <view class="row" style="justify-content:space-between; align-items:center; margin-bottom:32rpx;">
+    <view class="row" style="align-items:center; gap: 16rpx;" @tap="$emit('tap-avatar')">
+      <view class="claymorphism center" style="width:112rpx; height:112rpx; background: var(--accent1);">
+        <image
+          v-if="avatar"
+          :src="avatar"
+          mode="aspectFill"
+          style="width:80rpx;height:80rpx;border-radius:9999rpx;"
+          @error="$emit('avatar-error')"
+        ></image>
+        <view v-else class="center" style="width:80rpx;height:80rpx;border-radius:9999rpx;background:#fff;">🙂</view>
+      </view>
+      <view class="col">
+        <text class="text-sm" style="color:var(--text-dark);">Player</text>
+        <text class="text-2xl" style="color:var(--primary-dark); font-weight:700;">{{ username }}</text>
+      </view>
+    </view>
+
+    <button class="clay-button" style="padding: 16rpx; min-width:96rpx;" @tap="$emit('tap-settings')">
+      <view class="row center" style="gap:8rpx;">
+        <text style="font-size:40rpx;">⚙️</text>
+        <text class="text-sm" style="color:var(--text-dark);">设置</text>
+      </view>
+    </button>
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'UIHeader',
+  props: { username: { type: String, default: 'PlayerOne' }, avatar: { type: String, default: '' } }
+}
+</script>
+
+<style scoped></style>

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -2,41 +2,36 @@
   <view
     class="page col"
     :class="{ booted }"
-    style="position: relative;"
+    style="position: relative; padding:24rpx; gap:16rpx;"
     @touchstart="edgeHandlers.handleTouchStart"
     @touchmove="edgeHandlers.handleTouchMove"
     @touchend="edgeHandlers.handleTouchEnd"
     @touchcancel="edgeHandlers.handleTouchCancel"
   >
-    <view class="game-shell">
+    <UIHeader
+      :username="currentUserName"
+      :avatar="(!avatarLoadFailed && currentUserAvatar) ? currentUserAvatar : ''"
+      @tap-avatar="goLogin"
+      @tap-settings="goLogin"
+      @avatar-error="onAvatarError"
+    />
+    <view class="game-shell col" style="gap:16rpx;">
       <view class="game-header">
-        <!-- 顶部：当前用户 -->
-        <view class="topbar">
-          <view class="user-chip" hover-class="user-chip-hover" @tap="goLogin">
-            <template v-if="currentUserAvatar && !avatarLoadFailed">
-              <image class="user-chip-avatar" :src="currentUserAvatar" mode="aspectFill" @error="onAvatarError" />
-            </template>
-            <view v-else class="user-chip-fallback" :style="{ backgroundColor: currentUserColor }">{{ currentUserInitial }}</view>
-            <text class="user-chip-name">{{ currentUserName }}</text>
-          </view>
-        </view>
 
-        <view class="mode-bar">
+        <view class="claymorphism card mode-bar">
           <button
-            class="btn mode-toggle-btn"
+            class="clay-button mode-toggle-btn"
             :class="mode === 'pro' ? 'mode-toggle-pro' : 'mode-toggle-basic'"
             @click="toggleMode"
           >{{ modeButtonLabel }}</button>
-          <view style="flex:1;">
-            <button
-              class="btn btn-secondary deck-toggle-btn"
-              @click="toggleDeckSource"
-            >{{ deckSourceLabel }}</button>
-          </view>
+          <button
+            class="clay-button deck-toggle-btn"
+            @click="toggleDeckSource"
+          >{{ deckSourceLabel }}</button>
         </view>
 
         <!-- 本局统计：紧凑表格（1行表头 + 1行数据） -->
-        <view id="statsRow" class="card section stats-compact-table stats-card">
+        <view id="statsRow" class="claymorphism card stats-compact-table stats-card">
           <view class="thead">
             <text class="th">剩余</text>
             <text class="th">局数</text>
@@ -58,7 +53,7 @@
                 <text>{{ fmtMs1(handElapsedMs) }}</text>
               </block>
               <block v-else>
-                <button class="btn btn-secondary btn-reshuffle" @click.stop="reshuffle">洗牌</button>
+                <button class="clay-button btn-reshuffle" @click.stop="reshuffle">洗牌</button>
               </block>
             </view>
           </view>
@@ -82,26 +77,26 @@
 
             <!-- 运算符候选区：两行布局 -->
             <view id="opsRow1" :class="['ops-row-1', opsDensityClass]">
-              <button v-for="op in ['+','-','×','÷']" :key="op" class="btn btn-operator"
+              <button v-for="op in ['+','-','×','÷']" :key="op" class="clay-button btn-operator"
                       @touchstart.stop.prevent="startDrag({ type: 'op', value: op }, $event)"
                       @touchmove.stop.prevent="onDrag($event)"
                       @touchend.stop.prevent="endDrag()">{{ op }}</button>
             </view>
             <view id="opsRow2" :class="['ops-row-2', opsDensityClass]">
               <view class="ops-left">
-                <button v-for="op in ['(',')']" :key="op" class="btn btn-operator"
+                <button v-for="op in ['(',')']" :key="op" class="clay-button btn-operator"
                         @touchstart.stop.prevent="startDrag({ type: 'op', value: op }, $event)"
                         @touchmove.stop.prevent="onDrag($event)"
                         @touchend.stop.prevent="endDrag()">{{ op }}</button>
               </view>
-              <button class="btn btn-secondary mode-btn" @click="toggleFaceMode">{{ faceUseHigh ? 'J/Q/K=11/12/13' : 'J/Q/K=1' }}</button>
+              <button class="clay-button mode-btn" @click="toggleFaceMode">{{ faceUseHigh ? 'J/Q/K=11/12/13' : 'J/Q/K=1' }}</button>
             </view>
 
             <!-- 拖拽中的浮层 -->
             <view v-if="drag.active" class="drag-ghost" :style="ghostStyle">{{ ghostText }}</view>
 
             <!-- 表达式卡片容器（高度由脚本计算） -->
-            <view class="expr-card card section">
+            <view class="expr-card claymorphism-inset">
               <view
                 id="exprZone"
                 class="expr-zone"
@@ -139,8 +134,8 @@
                 </view>
               </view>
               <view class="basic-ops">
-                <button v-for="op in ['+','-','×','÷']" :key="'basic-op-' + op" class="btn btn-operator" :class="{ active: basicSelection.operator === op }" @tap="handleBasicOperator(op)">{{ op }}</button>
-                <button class="btn btn-secondary mode-btn basic-face-toggle" @click="toggleFaceMode">{{ faceUseHigh ? 'J/Q/K=11/12/13' : 'J/Q/K=1' }}</button>
+                <button v-for="op in ['+','-','×','÷']" :key="'basic-op-' + op" class="clay-button btn-operator" :class="{ active: basicSelection.operator === op }" @tap="handleBasicOperator(op)">{{ op }}</button>
+                <button class="clay-button mode-btn basic-face-toggle" @click="toggleFaceMode">{{ faceUseHigh ? 'J/Q/K=11/12/13' : 'J/Q/K=1' }}</button>
               </view>
               <view class="basic-column">
                 <view v-for="i in [1, 3]" :key="'basic-right-' + i" class="basic-card-wrapper">
@@ -158,20 +153,20 @@
 
         <view class="game-footer">
           <view id="submitRow" class="footer-row">
-            <button v-show="mode === 'pro'" class="btn btn-primary footer-primary-btn" @click="check">提交答案</button>
+            <button v-show="mode === 'pro'" class="clay-button-primary footer-primary-btn" @click="check">提交答案</button>
             <view v-show="mode !== 'pro'" class="basic-utility-grid">
-              <button class="btn btn-secondary" :disabled="!basicHistory.length" @click="undoBasicStep">后退</button>
-              <button class="btn btn-secondary" @click="resetBasicBoard">重置</button>
+              <button class="clay-button" :class="{ 'opacity-50': !basicHistory.length }" :disabled="!basicHistory.length" @click="undoBasicStep">后退</button>
+              <button class="clay-button" @click="resetBasicBoard">重置</button>
             </view>
           </view>
           <view id="failRow" class="footer-row">
             <view class="pair-grid footer-pair" v-show="mode === 'pro'">
-              <button class="btn btn-secondary" @click="showSolution">提示</button>
-              <button class="btn btn-secondary" @click="skipHand">下一题</button>
+              <button class="clay-button" @click="showSolution">提示</button>
+              <button class="clay-button" @click="skipHand">下一题</button>
             </view>
             <view class="pair-grid footer-pair" v-show="mode !== 'pro'">
-              <button class="btn btn-secondary" @click="showSolution">提示</button>
-              <button class="btn btn-secondary" @click="skipHand">下一题</button>
+              <button class="clay-button" @click="showSolution">提示</button>
+              <button class="clay-button" @click="skipHand">下一题</button>
             </view>
           </view>
         </view>
@@ -207,15 +202,15 @@
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>
 
-    <!-- ✅ 把自闭合组件改为成对闭合，避免误报 -->
-    <CustomTabBar></CustomTabBar>
+    <BottomTab />
   </view>
 </template>
 
 <script setup>
 import { ref, onMounted, onUnmounted, getCurrentInstance, computed, watch, nextTick } from 'vue'
 import { onHide, onShow } from '@dcloudio/uni-app'
-import CustomTabBar from '../../components/CustomTabBar.vue'
+import UIHeader from '../../components/UIHeader.vue'
+import BottomTab from '../../components/BottomTab.vue'
 import { evaluateExprToFraction, solve24 } from '../../utils/solver.js'
 import { ensureInit, getCurrentUser, getUsers, pushRound, readStatsExtended } from '../../utils/store.js'
 import {
@@ -1467,244 +1462,146 @@ function onSessionOver() {
 }
 </script>
 
-<style scoped> 
+<style scoped>
 .page {
-  min-height: 100dvh;
   min-height: calc(var(--vh, 1vh) * 100);
-  background: #f8fafc;
-  display:flex;
+  display: flex;
   flex-direction: column;
-  box-sizing:border-box;
-  padding:24rpx;
-  padding-bottom: calc(24rpx + env(safe-area-inset-bottom) + var(--tf24-tabbar-height, 120rpx) + (var(--tf24-footer-row-height, 120rpx) * 2) + var(--tf24-footer-gap, 16rpx));
+  box-sizing: border-box;
+  padding-bottom: calc(24rpx + env(safe-area-inset-bottom) + 240rpx);
 }
+
 .page { opacity: 0; }
 .page.booted { animation: page-fade-in .28s ease-out forwards; }
+
 .game-shell {
-  flex:1;
-  min-height:100%;
-  display:grid;
-  grid-template-rows:auto 1fr auto;
-  gap:24rpx;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
 }
+
 .game-header { display:flex; flex-direction:column; gap:16rpx; }
-.game-main { display:flex; flex-direction:column; min-height:400rpx; }
+.game-main { display:flex; flex-direction:column; gap:16rpx; }
 .mode-panels { flex:1; display:flex; flex-direction:column; gap:18rpx; }
 .mode-panel { display:flex; flex-direction:column; gap:18rpx; }
 .pro-mode { flex:1; }
-.topbar { padding: 12rpx 0; }
-.user-chip {
-  display:flex;
-  align-items:center;
-  gap:16rpx;
-  padding:12rpx 20rpx;
-  background:#fff;
-  border:2rpx solid #e2e8f0;
-  border-radius:9999rpx;
-  box-shadow:0 6rpx 16rpx rgba(15,23,42,0.08);
-  width:100%;
-  box-sizing:border-box;
-}
-.user-chip-avatar,
-.user-chip-fallback {
-  width:80rpx;
-  height:80rpx;
-  border-radius:50%;
-  flex:0 0 80rpx;
-}
-.user-chip-avatar { display:block; object-fit:cover; }
-.user-chip-fallback {
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:34rpx;
-  font-weight:700;
-  color:#0f172a;
-  background:#e2e8f0;
-}
-.user-chip-name {
-  flex:1;
-  font-size:32rpx;
-  font-weight:700;
-  color:#0f172a;
-  overflow:hidden;
-  text-overflow:ellipsis;
-  white-space:nowrap;
-}
-.user-chip-hover { opacity:0.86; }
- 
-/* 牌区 */ 
-.card-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:18rpx; } 
-.playing-card { background:None; border-radius:16rpx; overflow:hidden; box-shadow:0 8rpx 20rpx rgba(15,23,42,.08); border:1rpx solid #e5e7eb; } 
-.playing-card.used { filter: grayscale(1) saturate(.2); opacity:.5; } 
-.card-img { width:100%; height:auto; display:block; } 
 
-/* 运算符与按钮 */
-.ops-row-1 { display:grid; grid-template-columns:repeat(4,1fr); gap:18rpx; }
-.ops-row-2 { display:grid; grid-template-columns:1fr 1fr; gap:18rpx; align-items:stretch; }
-.ops-left { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; }
-.pair-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:18rpx; width:100%; }
-.mode-bar { display:flex; align-items:stretch; gap:18rpx; margin: 8rpx 0 16rpx; }
-.mode-btn { width: 100%; white-space: nowrap; }
-.mode-toggle-btn { flex:1; width:100%; border:2rpx solid transparent; font-weight:700; }
-.mode-toggle-basic { background:#145751; color:#fff; border-color:#145751; }
-.mode-toggle-pro { background:#1d4ed8; color:#fff; border-color:#1d4ed8; }
-.deck-toggle-btn {
-  width:100%;
-  margin: 8rpx;
-  padding:28rpx 36rpx;
-  white-space:normal;
-  word-wrap: break-word;
-  font-weight:700;
-  border:2rpx solid #145751;
-  color:#fff;
-  background:#3d5714;
+.mode-bar { display:flex; gap:16rpx; align-items:stretch; }
+.mode-toggle-btn { flex:1; font-weight:700; }
+.mode-toggle-pro { background: var(--primary); color:#fff; }
+.mode-toggle-basic { background: var(--accent1); color: var(--text-dark); }
+.deck-toggle-btn { flex:1; font-weight:700; white-space:normal; }
+
+.stats-compact-table { display:grid; grid-template-rows:auto auto; row-gap:12rpx; }
+.stats-compact-table .thead,
+.stats-compact-table .tbody { display:grid; grid-template-columns: repeat(7, 1fr); align-items:center; column-gap:12rpx; text-align:center; }
+.stats-compact-table .thead { color: var(--text-light); font-weight:700; font-size:26rpx; }
+.stats-compact-table .tbody { font-size:28rpx; color: var(--text-dark); }
+.stats-compact-table .ok { color:#1f8750; }
+.stats-compact-table .fail { color:#c84f4f; }
+.timer-cell { display:flex; align-items:center; justify-content:center; }
+
+.card-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:16rpx; }
+.playing-card {
+  background: var(--surface-light);
+  border-radius:24rpx;
+  overflow:hidden;
+  box-shadow: 6rpx 6rpx 12rpx rgba(0,0,0,0.08), -6rpx -6rpx 12rpx rgba(255,255,255,0.6);
+  border:2rpx solid rgba(255,255,255,0.4);
 }
+.playing-card.used { filter: grayscale(1) saturate(.2); opacity:.5; }
+.card-img { width:100%; height:auto; display:block; }
+
+.ops-row-1 { display:grid; grid-template-columns:repeat(4,1fr); gap:16rpx; }
+.ops-row-2 { display:grid; grid-template-columns:1fr 1fr; gap:16rpx; align-items:stretch; }
+.ops-left { display:grid; grid-template-columns:repeat(2,1fr); gap:16rpx; }
+.btn-operator { font-size:64rpx; font-weight:700; color:var(--text-dark); }
+.btn-operator.active { background: var(--primary); color:#fff; }
+
+.mode-btn { height:100%; font-weight:700; }
+.btn-reshuffle { font-size:28rpx; }
 
 .game-footer {
-  position:sticky;
-  bottom: calc(var(--tf24-tabbar-height, 120rpx) + env(safe-area-inset-bottom));
-  z-index:20;
+  position: sticky;
+  bottom: calc(env(safe-area-inset-bottom) + 160rpx);
   display:flex;
   flex-direction:column;
-  gap:var(--tf24-footer-gap, 16rpx);
-  padding:12rpx 0;
-  background: var(--tf24-footer-bg, #f8fafc);
-  box-shadow:0 -8rpx 20rpx rgba(15,23,42,0.12);
-  border-radius:24rpx;
-  min-height: var(--tf24-footer-total, calc(var(--tf24-footer-row-height, 120rpx) * 2 + var(--tf24-footer-gap, 16rpx)));
+  gap:16rpx;
+  padding:16rpx;
+  border-radius:30rpx;
+  background: var(--surface-light);
+  box-shadow: 8rpx 8rpx 16rpx var(--bg-dark), -8rpx -8rpx 16rpx #ffffff;
 }
-.footer-row {
-  display:flex;
-  align-items:stretch;
-  gap:18rpx;
-  min-height:var(--tf24-footer-row-height, 120rpx);
-}
-.footer-row .btn {
-  width:100%;
-  height:100%;
-  min-height:var(--tf24-footer-row-height, 120rpx);
-  padding:0;
-}
+
+.footer-row { display:flex; gap:16rpx; }
 .footer-primary-btn { width:100%; }
-.basic-utility-grid {
-  display:grid;
-  grid-template-columns:repeat(2,1fr);
-  gap:18rpx;
-  width:100%;
-}
-.basic-utility-grid .btn[disabled] { opacity:.6; }
-.footer-pair { height:100%; }
+.basic-utility-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:16rpx; }
+.pair-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:16rpx; width:100%; }
 
-.timer-cell { cursor: pointer; }
-.timer-popover-layer { position:fixed; inset:0; z-index:998; }
-.timer-popover { position:absolute; background:#fff; padding:18rpx 28rpx; border-radius:20rpx; box-shadow:0 16rpx 40rpx rgba(15,23,42,0.2); transform:translate(-50%, 0); display:flex; flex-direction:column; gap:12rpx; }
-.timer-popover-item { border:none; border-radius:12rpx; padding:16rpx 32rpx; background:#fee2e2; color:#b91c1c; font-size:28rpx; font-weight:700; }
-
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-
-.btn { border:none; border-radius:16rpx; padding:28rpx 0; font-size:32rpx; line-height:1; box-shadow:0 8rpx 20rpx rgba(15,23,42,.06); width:100%; display:flex; align-items:center; justify-content:center; box-sizing:border-box; }
-.btn-operator { background:#fff; color:#2563eb; border:2rpx solid #e5e7eb; font-size:64rpx;font-weight: bold;}
-.btn-primary { background:#145751; color:#fff; }
-/* 使用全局 .btn-secondary 样式（uni.scss）以保持一致性 */
-
-/* 成功动画覆盖层 */
 .success-overlay { position:absolute; left:0; right:0; top:0; bottom:0; display:flex; align-items:center; justify-content:center; pointer-events:none; }
-.success-burst { background: rgba(34,197,94,0.92); color:#fff; font-weight:800; font-size:64rpx; padding:40rpx 60rpx; border-radius:9999rpx; box-shadow:0 16rpx 40rpx rgba(34,197,94,.35); animation: success-pop .5s ease-out both; }
+.success-burst { background: var(--accent2); color:var(--text-dark); font-weight:800; font-size:64rpx; padding:40rpx 60rpx; border-radius:9999rpx; box-shadow:0 16rpx 40rpx rgba(0,0,0,.12); animation: success-pop .5s ease-out both; }
 .error-burst { background: rgba(239,68,68,0.92); color:#fff; font-weight:800; font-size:48rpx; padding:28rpx 40rpx; border-radius:9999rpx; box-shadow:0 16rpx 40rpx rgba(239,68,68,.35); animation: success-pop .5s ease-out both; display:flex; flex-direction:column; align-items:center; gap:6rpx }
 .error-burst .err-title{ font-size:48rpx; font-weight:800 }
 .error-burst .err-val{ font-size:28rpx; font-weight:700; opacity:.95 }
-@keyframes success-pop { 0% { transform: scale(.6); opacity: 0; } 50% { transform: scale(1.05); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
 
-/* 表达式区 */
-.expr-card { background:#fff; padding:20rpx; border-radius:16rpx; border:2rpx solid #e5e7eb; box-shadow:0 6rpx 20rpx rgba(0,0,0,.06); } 
-.expr-title { margin-top: 0; color:#111827; font-size:30rpx; font-weight:600; }
-.status-text { color:#1f2937; font-weight:700; }
-.expr-zone { --tok-card-h: 112rpx; --card-w-ratio: 0.714; margin-top: 8rpx; background:#f5f7fb; border:2rpx dashed #d1d5db; border-radius:24rpx; padding:28rpx; overflow:hidden; position:relative;}
-.expr-override {
-  position:absolute;
-  inset:0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
-  padding:0 32rpx;
-  color:#1f2937;
-  font-size:30rpx;
-  font-weight:700;
-  background:rgba(245,247,251,0.92);
-  pointer-events:none;
-  z-index:2;
-}
-.expr-zone-active { border-color:#3a7afe; }
-.expr-placeholder { color:#9ca3af; text-align:center; margin-top: 8rpx; }
-.expr-row { display:inline-flex; flex-wrap:nowrap; white-space:nowrap; gap:12rpx; align-items:center; }
-/* 只有在 empty 状态下显示提示 */
+.expr-card { border-radius:24rpx; padding:24rpx; background: var(--surface-light); box-shadow: inset 6rpx 6rpx 12rpx rgba(0,0,0,0.05), inset -6rpx -6rpx 12rpx rgba(255,255,255,0.6); border:2rpx solid rgba(255,255,255,0.4); }
+.expr-zone { --tok-card-h: 112rpx; --card-w-ratio: 0.714; margin-top: 8rpx; border-radius:24rpx; padding:28rpx; overflow:hidden; position:relative; background: var(--surface-dark); box-shadow: inset 6rpx 6rpx 12rpx var(--bg-dark), inset -6rpx -6rpx 12rpx #ffffff; }
 .expr-zone.empty::after {
   content: "表达式区域";
   position: absolute;
-  inset: 0;                  /* 覆盖容器，但不改变布局 */
-  display: flex;             /* 仅用于居中文案 */
+  inset: 0;
+  display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;      /* 不拦截拖拽/点击 */
-  color: #9aa3af;            /* 轻提示色 */
+  pointer-events: none;
+  color: rgba(67,78,90,0.6);
   font-size: 26rpx;
-  letter-spacing: 1rpx;
-  user-select: none;
-  /* 可以按需加淡入效果（可选）
-  opacity: 1;
-  transition: opacity .18s ease;
-  */
 }
-.tok { color:#1f3a93; border-radius:14rpx; transition: transform 180ms ease, opacity 180ms ease, box-shadow 180ms ease; }
+.expr-zone-active { box-shadow: inset 4rpx 4rpx 8rpx var(--bg-dark), inset -4rpx -4rpx 8rpx #ffffff; }
+.expr-row { display:inline-flex; flex-wrap:nowrap; white-space:nowrap; gap:12rpx; align-items:center; }
+.tok { color:var(--text-dark); border-radius:14rpx; transition: transform 180ms ease, opacity 180ms ease, box-shadow 180ms ease; }
 .tok.num { padding:0; border:none; background:transparent; width: calc(var(--tok-card-h) * var(--card-w-ratio)); height: var(--tok-card-h); display:inline-block; }
-.tok-card-img { width:100%; height:100%; object-fit: contain; display:block; border-radius:14rpx; box-shadow:0 6rpx 20rpx rgba(15,23,42,.08); }
-.tok.op { height: var(--tok-card-h); width: calc(var(--tok-card-h) * var(--card-w-ratio) / 2); padding: 0; font-size: calc(var(--tok-card-h) * 0.42); background:#fff; border:2rpx solid #e5e7eb; display:flex; align-items:center; justify-content:center; box-shadow:0 6rpx 20rpx rgba(15,23,42,.06); box-sizing: border-box; }
+.tok-card-img { width:100%; height:100%; object-fit: contain; display:block; border-radius:14rpx; box-shadow:0 6rpx 20rpx rgba(0,0,0,.08); }
+.tok.op { height: var(--tok-card-h); width: calc(var(--tok-card-h) * var(--card-w-ratio) / 2); padding: 0; font-size: calc(var(--tok-card-h) * 0.42); background: var(--surface-light); box-shadow: 6rpx 6rpx 12rpx rgba(0,0,0,0.08), -6rpx -6rpx 12rpx rgba(255,255,255,0.6); display:flex; align-items:center; justify-content:center; box-sizing: border-box; }
 .tok.dragging { opacity:.6; box-shadow:0 6rpx 24rpx rgba(0,0,0,.18); }
 .tok.just-inserted { animation: pop-in 200ms ease-out; }
-.insert-placeholder { border-radius:14rpx; border:2rpx dashed #3a7afe; background:#eaf1ff; opacity:.9; position:relative; overflow:hidden; }
+.insert-placeholder { border-radius:14rpx; border:2rpx dashed rgba(100,162,197,0.8); background:rgba(152,210,235,0.3); opacity:.9; position:relative; overflow:hidden; }
 .insert-placeholder.num { min-width: calc(var(--tok-card-h) * var(--card-w-ratio)); min-height: var(--tok-card-h); margin:2rpx; }
 .insert-placeholder.op { min-width: calc(var(--tok-card-h) * var(--card-w-ratio) / 2); min-height: var(--tok-card-h); margin:2rpx; }
-.insert-placeholder::before { content:''; position:absolute; inset:0; background:repeating-linear-gradient(60deg, rgba(58,122,254,0.05) 0, rgba(58,122,254,0.05) 8rpx, rgba(58,122,254,0.18) 8rpx, rgba(58,122,254,0.18) 16rpx); background-size:200% 100%; animation:shimmer 1.2s linear infinite; }
-.drag-ghost { position:fixed; z-index:9999; background:#3a7afe; color:#fff; padding:16rpx 22rpx; border-radius:10rpx; font-size:32rpx; pointer-events:none; }
-
-/* 统计：单行紧凑 */
-.stats-card { background:#fff; border:2rpx solid #e5e7eb; border-radius:16rpx; padding:16rpx; } 
-.stats-compact-table { display:grid; grid-template-rows:auto auto; row-gap:8rpx; }
-.stats-compact-table .thead, .stats-compact-table .tbody { display:grid; grid-template-columns: repeat(7, 1fr); align-items:center; column-gap:12rpx; }
-.stats-compact-table .thead { color:#6b7280; font-weight:700; font-size:26rpx; text-align: center;}
-.stats-compact-table .tbody { font-size:28rpx; text-align: center;}
-.stats-compact-table .ok { color:#16a34a; font-weight:700 }
-.stats-compact-table .fail { color:#dc2626; font-weight:700 }
-.stats-one-line .stats-item { display:flex; align-items:center; gap:6rpx; padding:4rpx 8rpx; border-right:2rpx solid #e5e7eb; }
-.stats-one-line .stats-item:last-child { border-right:none; }
-.stat-label { color:#6b7280; font-size:26rpx; }
-.stat-label.ok, .stat-value.ok { color:#16a34a; font-weight:700 }
-.stat-label.fail, .stat-value.fail { color:#dc2626; font-weight:700 }
-.stat-value { font-weight:700; color:#111827; font-size:28rpx; }
-
-.btn-reshuffle { padding: 12rpx 0; font-size: 26rpx; line-height: 1; }
+.insert-placeholder::before { content:''; position:absolute; inset:0; background:repeating-linear-gradient(60deg, rgba(152,210,235,0.1) 0, rgba(152,210,235,0.1) 8rpx, rgba(100,162,197,0.2) 8rpx, rgba(100,162,197,0.2) 16rpx); background-size:200% 100%; animation:shimmer 1.2s linear infinite; }
+.drag-ghost { position:fixed; z-index:9999; background:var(--primary); color:#fff; padding:16rpx 22rpx; border-radius:10rpx; font-size:32rpx; pointer-events:none; box-shadow:0 12rpx 24rpx rgba(0,0,0,.18); }
 
 .basic-mode { display:flex; flex-direction:column; gap:24rpx; flex:1; }
 .basic-board { display:flex; gap:24rpx; align-items:stretch; justify-content:center; }
 .basic-column { display:flex; flex-direction:column; gap:24rpx; flex:1; }
 .basic-card-wrapper { flex:1; }
-.basic-card { background:None; border-radius:8rpx; box-shadow:0 12rpx 28rpx rgba(15,23,42,.12); border:2rpx solid transparent; overflow:hidden; position:relative; display:flex; align-items:center; justify-content:center; min-height:320rpx; transition:border-color 0.2s ease, box-shadow 0.2s ease; }
+.basic-card {
+  border-radius:24rpx;
+  background: var(--surface-light);
+  box-shadow: 10rpx 10rpx 20rpx rgba(0,0,0,0.12), -10rpx -10rpx 20rpx rgba(255,255,255,0.6);
+  border:2rpx solid rgba(255,255,255,0.5);
+  overflow:hidden;
+  position:relative;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  min-height:320rpx;
+  transition:border-color 0.2s ease, box-shadow 0.2s ease;
+}
 .basic-card.hidden { visibility:hidden; pointer-events:none; }
-.basic-card.selected { border-color:#145751; box-shadow:0 16rpx 32rpx rgba(20,87,81,.22); }
-.basic-card.result { background:#fef3c7; }
+.basic-card.selected { border-color: var(--primary); box-shadow: 10rpx 10rpx 24rpx rgba(100,162,197,0.32), -10rpx -10rpx 24rpx rgba(255,255,255,0.8); }
+.basic-card.result { background: var(--accent1); }
 .basic-card-img { width:100%; height:100%; object-fit:contain; }
-.basic-card-value { width:100%; height:100%; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg, #fefce8 0%, #fde68a 100%); }
-.basic-card-value-text { font-size:72rpx; font-weight:700; color:#1f2937; }
+.basic-card-value { width:100%; height:100%; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg, #fff4de 0%, #f9c897 100%); }
+.basic-card-value-text { font-size:72rpx; font-weight:700; color:var(--text-dark); }
 .basic-ops { display:flex; flex-direction:column; gap:20rpx; align-items:stretch; justify-content:center; flex:0 0 160rpx; }
-.basic-ops .btn-operator { height:110rpx; font-size:64rpx; }
-.basic-ops .btn-operator.active { background:#145751; color:#fff; border-color:#145751; }
-.basic-face-toggle { margin-top:12rpx; white-space:normal;word-break: break-all;}
+.basic-ops .btn-operator { height:110rpx; }
+.basic-ops .btn-operator.active { background: var(--primary); color:#fff; }
+.basic-face-toggle { margin-top:12rpx; white-space:normal; word-break: break-all; }
 
 @keyframes pop-in { from { transform:scale(0.85); opacity:.2; } to { transform:scale(1); opacity:1; } }
 @keyframes shimmer { from { background-position-x:0%; } to { background-position-x:200%; } }
+@keyframes success-pop { 0% { transform: scale(.6); opacity: 0; } 50% { transform: scale(1.05); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
 @keyframes page-fade-in { from { opacity: 0; } to { opacity: 1; } }
 </style>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -1,36 +1,33 @@
 <template>
   <view
-    class="login-page"
+    class="page col"
+    style="padding:24rpx; gap:16rpx;"
     @touchstart="edgeHandlers.handleTouchStart"
     @touchmove="edgeHandlers.handleTouchMove"
     @touchend="edgeHandlers.handleTouchEnd"
     @touchcancel="edgeHandlers.handleTouchCancel"
   >
-    <!-- 顶部栏 -->
-    <view class="login-topbar">
-      <!-- <button class="icon-btn" @tap="goBack">←</button> -->
-      <text class="login-title">无敌24点程序·观测</text>
-      <!-- <view style="width:40rpx"></view> -->
-    </view>
+    <UIHeader
+      :username="headerTitle"
+      @tap-avatar="refresh"
+      @tap-settings="createUser"
+    />
 
     <!-- 主体 -->
     <view class="login-body">
-      <view class="login-heading">
-        <text class="h1">选择玩家</text>
-      </view>
 
       <!-- 错误状态 -->
-      <view v-if="errMsg" class="error-card card section">
+      <view v-if="errMsg" class="claymorphism card error-card">
         <text class="err-title">数据异常</text>
         <text class="err-text">{{ errMsg }}</text>
-        <button class="btn danger" @tap="resetData">重置数据</button>
+        <button class="clay-button" @tap="resetData">重置数据</button>
       </view>
 
       <!-- 空状态 -->
-      <view v-else-if="(sortedUsers.length === 0)" class="empty-card card section">
+      <view v-else-if="(sortedUsers.length === 0)" class="claymorphism card empty-card">
         <text class="empty-ill">🃏</text>
         <text class="empty-text">还没有玩家，快创建一个吧！</text>
-        <button class="create-btn highlight" @tap="createUser">
+        <button class="clay-button-primary create-btn" @tap="createUser">
           <text class="create-plus">＋</text>
           <text>新建玩家</text>
         </button>
@@ -38,7 +35,7 @@
 
       <!-- 用户列表 -->
       <view v-else class="user-list">
-        <button class="user-item card section" v-for="u in sortedUsers" :key="u.id" @tap="choose(u)">
+        <button class="user-item claymorphism card" v-for="u in sortedUsers" :key="u.id" @tap="choose(u)">
           <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
           <view v-else class="avatar" :style="{ backgroundColor: u.color || colorFrom(u) }">{{ avatarText(u.name) }}</view>
           <view class="user-col">
@@ -49,7 +46,7 @@
           </view>
           <text class="chev">›</text>
         </button>
-        <button class="create-btn" @tap="createUser">
+        <button class="clay-button create-btn" @tap="createUser">
           <text class="create-plus">＋</text>
           <text>新建玩家</text>
         </button>
@@ -70,6 +67,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import UIHeader from '../../components/UIHeader.vue'
 import { ensureInit, getUsers, addUser, switchUser, resetAllData, touchLastPlayed } from '../../utils/store.js'
 import { saveAvatarForUser } from '../../utils/avatar.js'
 import { useFloatingHint } from '../../utils/hints.js'
@@ -78,6 +76,7 @@ import { exitApp } from '../../utils/navigation.js'
 
 const users = ref({ list: [], currentId: '' })
 const errMsg = ref('')
+const headerTitle = computed(() => '选择玩家')
 
 const { hintState, showHint, hideHint } = useFloatingHint()
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitLoginPage() })
@@ -213,135 +212,29 @@ function resetData(){
 </script>
 
 <style scoped>
- .login-page {
-  /* 视口高度填满，兼容移动端动态地址栏 */
-  min-height: 100dvh;
-  min-height: calc(var(--vh, 1vh) * 100);
-  background: #f1f5f9;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;  /* 防止整体滚动 */
-}
-body {
-  overflow: hidden;
-  height: 100vh;
-}
-.login-topbar{ display:flex; align-items:center; padding:24rpx; gap:12rpx }
-/* .icon-btn{ width:64rpx; height:64rpx; border-radius:50%; background:#e5e7eb; display:flex; align-items:center; justify-content:center; border:none; } */
-.login-title{ flex:1; text-align:center; font-weight:900; font-size:36rpx; color:#0e141b; letter-spacing:-0.5rpx }
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-.login-body {
-  flex: 1;  /* 占据剩余空间 */
-  padding: 10rpx 2.5rpx 0 2.5rpx;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;  /* 防止溢出 */
-  min-height: 0;  /* 允许收缩 */
-  height: 0;  /* 强制高度约束 */
-}
-.login-heading { 
-  flex-shrink: 0;  /* 不收缩 */
-  text-align: center; 
-  margin: 0rpx 0 24rpx 0;
-  height: 80rpx;  /* 固定高度 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.h1{ font-size:56rpx; font-weight:900; color:#0e141b }
-.user-list {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 20rpx;
-  padding: 0 100rpx 20rpx 100rpx;  /* 改为padding，不用margin */
-  overflow-y: auto;
-  min-height: 0;
-  height: 0;  /* 强制高度约束 */
-}
-/* 滚动条样式优化 */
-.user-list::-webkit-scrollbar {
-  width: 6rpx;
-}
+.login-body { display:flex; flex-direction:column; gap:16rpx; }
 
-.user-list::-webkit-scrollbar-track {
-  background: transparent;
-}
+.error-card { display:flex; flex-direction:column; gap:12rpx; text-align:center; }
+.err-title { font-size:32rpx; font-weight:800; color:var(--text-dark); }
+.err-text { font-size:26rpx; color:var(--text-light); }
 
-.user-list::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 3rpx;
-}
+.empty-card { display:flex; flex-direction:column; align-items:center; gap:16rpx; text-align:center; padding:32rpx 16rpx; }
+.empty-ill { font-size:80rpx; }
+.empty-text { font-size:28rpx; color:var(--text-light); }
+.create-btn { display:flex; align-items:center; justify-content:center; gap:12rpx; font-size:28rpx; font-weight:700; padding:16rpx 24rpx; }
+.create-plus { font-size:36rpx; }
 
-.user-list::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
-}
-.user-item{ display:flex; align-items:center; padding:10rpx; height:100rpx;width:100%; border-radius:12rpx; border:2rpx solid #cfd8e3; background:#ffffff; box-shadow:0 2rpx 4rpx rgba(15,23,42,0.02) }
-.user-item:active{ transform:scale(0.98) }
-.avatar{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#0f172a; margin-right:20rpx }
-.avatar-img{ width:72rpx; height:72rpx; border-radius:50%; margin-right:20rpx; background:#e2e8f0 }
-.user-col{
-  flex:1;
-  display:grid;
-  /* 方案A：定宽（最稳妥，确保“最近程序”纵向齐） */
-  grid-template-columns: minmax(0, 200rpx) 1fr;  /* ← 原来是 auto 1fr */
-  /* 也可用半定宽：grid-template-columns: minmax(240rpx, 36vw) 1fr; 
-     （注意小程序端对 clamp/minmax 的兼容性，H5/App 正常） */
-  align-items:left;
-  justify-items:start;                /* ✅ 内容在各列内靠左 */
-  column-gap:10rpx; 
-  min-width:0;
-}
-.user-name {
-  font-size:34rpx;
-  color:#0f172a;
-  font-weight:700;
-  white-space:nowrap;               /* ✅ 不换行 */
-  overflow:hidden;
-  text-overflow:ellipsis;           /* ✅ 超长省略号 */
-  text-align:left;                    /* ✅ 明确指定左对齐 */
-  width: 100%;      /* 关键修复 */
-  max-width: 100%;  /* 双重保险 */
-}
-.user-sub {
-  font-size:20rpx;
-  color:#64748b;
-  white-space:nowrap;
-  align-self:center;                     /* ✅ 单独确保这一列底对齐 */
-}
-.chev{
-  flex:0 0 auto;          /* 不要挤压中间列 */
-  width: 40rpx;           /* 可选：固定宽度，视觉更稳 */
-  text-align:right;
-  color:#94a3b8; font-size:40rpx; font-weight:800; margin-left:12rpx;
-}
-.create-btn{ margin-top:20rpx; height:100rpx; border-radius:24rpx; background:#e2e8f0; color:#0f172a; font-size:32rpx; font-weight:800; border:none; display:flex; align-items:center; justify-content:center; gap:12rpx }
-.create-btn.highlight{ background:#145751; color:#fff }
-.create-plus{ font-size:36rpx }
-/* 底部区块相关样式已移除（guest 入口下线） */
-button{ -webkit-tap-highlight-color:rgba(0,0,0,0) }
+.user-list { display:flex; flex-direction:column; gap:16rpx; }
+.user-item { display:flex; align-items:center; gap:16rpx; padding:16rpx; border-radius:24rpx; }
+.user-item:active { box-shadow: inset 4rpx 4rpx 8rpx var(--bg-dark), inset -4rpx -4rpx 8rpx #ffffff; }
+.avatar-img, .avatar { width:96rpx; height:96rpx; border-radius:9999rpx; }
+.avatar { display:flex; align-items:center; justify-content:center; font-size:36rpx; font-weight:700; color:#fff; background:var(--primary-dark); }
+.user-col { flex:1; display:flex; flex-direction:column; gap:6rpx; }
+.user-name { font-size:32rpx; font-weight:700; color:var(--text-dark); }
+.user-sub { font-size:24rpx; color:var(--text-light); }
+.chev { font-size:40rpx; color:var(--text-light); }
 
-/* 空/错 视图 */
-.empty-card, .error-card {
-  flex: 1;  /* 占据可用空间 */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;  /* 垂直居中 */
-  gap: 16rpx;
-  padding: 40rpx 24rpx;
-  margin: 50rpx 100rpx;
-  border-radius: 24rpx;
-  background: #fff;
-  border: 2rpx solid #e5e7eb;
-  max-height: 100%;  /* 不超出容器 */
-  overflow-y: auto;  /* 如果内容过多也能滚动 */
-}
-.empty-ill{ font-size:88rpx }
-.empty-text{ color:#6b7280 }
-.err-title{ font-weight:800; color:#b91c1c }
-.err-text{ color:#6b7280; text-align:center }
-.btn.danger{ background:#ef4444; color:#fff; border:none; padding:20rpx 28rpx; border-radius:14rpx }
+.floating-hint-layer { position:fixed; left:0; right:0; top:0; bottom:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999; }
+.floating-hint-layer.interactive { pointer-events:auto; }
+.floating-hint { background:rgba(67,78,90,0.9); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; font-size:28rpx; box-shadow:0 12rpx 24rpx rgba(0,0,0,0.25); }
 </style>

--- a/pages/stats/index.vue
+++ b/pages/stats/index.vue
@@ -1,22 +1,28 @@
 <template>
   <view
-    class="page"
-    style="padding:24rpx; display:flex; flex-direction:column; gap:18rpx;"
+    class="page col"
+    style="padding:24rpx; gap:16rpx;"
     @touchstart="edgeHandlers.handleTouchStart"
     @touchmove="edgeHandlers.handleTouchMove"
     @touchend="edgeHandlers.handleTouchEnd"
     @touchcancel="edgeHandlers.handleTouchCancel"
   >
-    <view class="section">
+    <UIHeader
+      :username="headerName"
+      @tap-avatar="goUserPage"
+      @tap-settings="goUserPage"
+    />
+
+    <view class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center; gap:12rpx; flex-wrap:wrap;">
         <text class="title">玩家总览</text>
         <view class="row" style="display:flex; align-items:center; gap:12rpx;">
           <view class="seg">
-            <button class="seg-btn" :class="{ active: overviewRange===1 }" @click="setOverviewRange(1)">今天</button>
-            <button class="seg-btn" :class="{ active: overviewRange===3 }" @click="setOverviewRange(3)">3天</button>
-            <button class="seg-btn" :class="{ active: overviewRange===7 }" @click="setOverviewRange(7)">7天</button>
-            <button class="seg-btn" :class="{ active: overviewRange===30 }" @click="setOverviewRange(30)">30天</button>
-            <button class="seg-btn" :class="{ active: overviewRange===0 }" @click="setOverviewRange(0)">全部</button>
+            <button class="seg-btn clay-button" :class="{ active: overviewRange===1 }" @click="setOverviewRange(1)">今天</button>
+            <button class="seg-btn clay-button" :class="{ active: overviewRange===3 }" @click="setOverviewRange(3)">3天</button>
+            <button class="seg-btn clay-button" :class="{ active: overviewRange===7 }" @click="setOverviewRange(7)">7天</button>
+            <button class="seg-btn clay-button" :class="{ active: overviewRange===30 }" @click="setOverviewRange(30)">30天</button>
+            <button class="seg-btn clay-button" :class="{ active: overviewRange===0 }" @click="setOverviewRange(0)">全部</button>
           </view>
         </view>
       </view>
@@ -56,14 +62,14 @@
 
     <view v-if="selectedUserId" class="section title">
       <view class="user-picker" style="display:flex; align-items:center; gap:8rpx;">
-        <!-- <text style="color:#6b7280; font-size:26rpx;">查看</text> -->
+        <!-- <text style="color:var(--text-light); font-size:26rpx;">查看</text> -->
         <picker :range="userOptions" range-key="name" @change="onUserChange">
           <view class="picker-trigger">{{ selectedUserLabel }}</view>
         </picker>
       </view>
     </view>
 
-    <view v-if="selectedUserId" class="section">    
+    <view v-if="selectedUserId" class="claymorphism card section">    
       <view class="row" style="justify-content:space-between; align-items:center; gap:12rpx; flex-wrap: wrap;">
         <text class="title">📈个人趋势</text>
       </view>
@@ -88,7 +94,7 @@
                 :style="{ width: trendSeries.barWidth + 'rpx' }">{{ d.shortLabel }}</text>
         </view>
       </view>
-      <view class="trend-legend" style="margin-top:8rpx; color:#6b7280; font-size:24rpx;">绿色=胜利局数，红色=失败局数</view>
+      <view class="trend-legend" style="margin-top:8rpx; color:var(--text-light); font-size:24rpx;">绿色=胜利局数，红色=失败局数</view>
       <!-- <view class="table" style="margin-top:12rpx;">
         <view class="thead" :style="{ display:'grid', gridTemplateColumns:'1fr 1fr 1fr' }">
           <text class="th">窗口</text>
@@ -126,7 +132,7 @@
       </view>
     </view>
 
-    <view v-if="selectedUserId" class="section">
+    <view v-if="selectedUserId" class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center;">
         <text class="title">最近战绩</text>
       </view>
@@ -147,7 +153,7 @@
       <view v-else class="empty-tip">暂无最近战绩</view>
     </view>
 
-    <view v-if="selectedUserId" class="section">
+    <view v-if="selectedUserId" class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center; gap:12rpx; flex-wrap:wrap;">
         <text class="title">📝错题本</text>
         <text class="mistake-tip">连续正确 5 次将自动移出活动错题本（但仍计入总错题统计）</text>
@@ -190,7 +196,7 @@
     </view>
 
     <!-- 称号系统（基础版） -->
-    <view v-if="selectedUserId" class="section">
+    <view v-if="selectedUserId" class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center;">
         <text class="title">称号</text>
       </view>
@@ -200,7 +206,7 @@
     </view>
 
     <!-- 速度-准确概览（时间分桶） -->
-    <view v-if="selectedUserId" class="section">
+    <view v-if="selectedUserId" class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center;">
         <text class="title">速度-准确概览</text>
       </view>
@@ -229,7 +235,7 @@
     </view>
 
     <!-- 技能雷达（表格版） -->
-    <view v-if="selectedUserId" class="section">
+    <view v-if="selectedUserId" class="claymorphism card section">
       <view class="row" style="justify-content:space-between; align-items:center;">
         <text class="title">技能雷达（表格版）</text>
       </view>
@@ -257,12 +263,13 @@
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>
   </view>
-  <CustomTabBar />
+  <BottomTab />
 </template>
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue'
-import CustomTabBar from '../../components/CustomTabBar.vue'
+import UIHeader from '../../components/UIHeader.vue'
+import BottomTab from '../../components/BottomTab.vue'
 import MiniBar from '../../components/MiniBar.vue'
 import { onShow, onPullDownRefresh } from '@dcloudio/uni-app'
 import { ensureInit, allUsersWithStats, readStatsExtended, getCurrentUser } from '../../utils/store.js'
@@ -288,6 +295,7 @@ const hintFilter = ref('all') // all | hint | nohint（全局）
 const selectedUserId = ref('')
 const userOptions = computed(() => rows.value.map(r => ({ id: r.id, name: r.name })))
 const selectedUserLabel = computed(() => (userOptions.value.find(o => o.id === selectedUserId.value)?.name) || '请选择用户')
+const headerName = computed(() => selectedUserId.value ? selectedUserLabel.value : '统计面板')
 const userExtMap = ref({}) // { uid: { rounds, totals, agg, days } }
 const userMap = computed(() => {
   const map = {}
@@ -934,219 +942,112 @@ function exitStatsPage() {
     },
   })
 }
+
+function goUserPage(){
+  try { uni.switchTab({ url:'/pages/user/index' }) }
+  catch (_) {
+    try { uni.navigateTo({ url:'/pages/user/index' }) }
+    catch (__) {}
+  }
+}
 </script>
 
 <style scoped>
-.page{ min-height:100vh; box-sizing:border-box; position:relative; }
-.section{ background:#fff; border:2rpx solid #e5e7eb; border-radius:16rpx; padding:16rpx; box-shadow:0 6rpx 16rpx rgba(15,23,42,.06) }
-.section.title{ background:none; font-size:36rpx; font-weight:800; margin-bottom:12rpx }
-.title{ font-size:32rpx; font-weight:800 }
-.table { 
-  margin-top: 12rpx; 
-  border-radius: 12rpx; 
-  overflow: hidden; 
-  border: 1rpx solid #e5e7eb; 
+.page {
+  min-height: calc(var(--vh, 1vh) * 100);
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
 }
-.thead, .tr { 
-  display: grid; 
-  grid-template-columns: 40rpx 1fr 120rpx 120rpx 80rpx 80rpx 80rpx; 
-  align-items: center; 
-  grid-gap: 6rpx; 
-  min-height: 44rpx;
+
+.section { display:flex; flex-direction:column; gap:16rpx; }
+.section.title { gap:8rpx; background: transparent; box-shadow:none; border:none; }
+.title { font-size:32rpx; font-weight:800; color:var(--text-dark); }
+
+.table {
+  margin-top: 12rpx;
+  border-radius: 24rpx;
+  overflow: hidden;
+  border: 1rpx solid rgba(255,255,255,0.4);
+  background: var(--surface-light);
+  box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6);
 }
+
+.thead, .tr {
+  display: grid;
+  align-items: center;
+  gap: 8rpx;
+  padding: 12rpx 16rpx;
+  font-size: 26rpx;
+}
+
 .thead {
-  color: var(--tf24-table-head-color, #475569);
-  font-weight: 700;
-  padding: 8rpx 12rpx;
-  background: var(--tf24-table-head-bg, #f8fafc);
-  font-size: 24rpx;
-}
-.tr { 
-  padding: 10rpx 12rpx; 
-  border-top: 1rpx solid #f1f5f9;
-  font-size: 26rpx;
-  transition: background-color 0.2s;
-}
-.th, .td { 
-  text-align: center; 
-  overflow: hidden; 
-  text-overflow: ellipsis; 
-  white-space: nowrap;
-  line-height: 1.4;
-}
-.rank { 
-  text-align: center; 
-  font-weight: 600;
-}
-.td.rank {
-  color: #64748b;
-  font-size: 24rpx;
+  font-weight:700;
+  color: var(--text-light);
+  background: rgba(255,255,255,0.6);
 }
 
-.td.user {
-  font-weight: 600;
-  color: #1e293b;
-}
-.ok { 
-  color: #059669; 
-  font-weight: 700; 
+.tbody .tr {
+  border-top: 1rpx solid rgba(255,255,255,0.4);
+  color: var(--text-dark);
 }
 
-.fail { 
-  color: #dc2626; 
-  font-weight: 700; 
-}
-/* 数值列居中对齐，更紧凑 */
-.th:nth-child(3), .th:nth-child(4), .th:nth-child(5), .th:nth-child(6), .th:nth-child(7),
-.td:nth-child(3), .td:nth-child(4), .td:nth-child(5), .td:nth-child(6), .td:nth-child(7) {
+.th, .td {
   text-align: center;
-}
-
-/* 胜率列特殊样式 */
-.td:nth-child(5) {
-  font-weight: 600;
-  color: #0891b2;
-}
-
-/* 最佳成绩列特殊样式 */
-.td:nth-child(7) {
-  font-weight: 600;
-  color: #7c3aed;
-}
-.btn.mini{ padding:10rpx 16rpx; border-radius:12rpx; background:#eef2f7 }
-.btn.link{ background:transparent; color:#2563eb }
-.seg{ display:flex; background:#f1f5f9; border-radius:12rpx; overflow:hidden }
-.seg-btn{ padding:10rpx 16rpx; background:transparent; border:none }
-.seg-btn.active{ background:#fff; font-weight:700 }
-.trend-chart{ width:100%; overflow-x:auto; }
-.trend-chart-inner{ position:relative; }
-.trend-bars{ display:flex; align-items:flex-end; height:100%; }
-.trend-item{ display:flex; justify-content:center; align-items:flex-end; height:100%; }
-.trend-item .bar{ width:100%; display:flex; flex-direction:column; justify-content:flex-end; border-radius:12rpx 12rpx 0 0; overflow:hidden; background:#f1f5f9; }
-.trend-item .bar-fail{ width:100%; background:#dc2626; }
-.trend-item .bar-success{ width:100%; background:#16a34a; }
-.trend-labels{ display:flex; justify-content:flex-start; margin-top:6rpx; }
-.trend-labels .bar-label{ text-align:center; color:#64748b; font-size:22rpx; white-space:nowrap; }
-.trend-labels.rotate {
-  min-height: 60rpx;
-  align-items: flex-end;
-}
-.trend-labels.rotate .bar-label {
-  display: inline-block;        /* 让 transform 生效 */
-  transform: rotate(-90deg);    /* 顺时针或逆时针旋转 */
-  transform-origin: center center;  /* 旋转参考点，可以根据需求改为 left bottom 等 */
-  white-space: nowrap;
-}
-.rounds{
-  margin-top:12rpx;
-  display:flex;
-  flex-direction:column;
-  row-gap:16rpx;
-  --recent-rounds-grid: 200rpx 120rpx 160rpx 1fr;
-}
-.rounds-head{
-  display:grid;
-  grid-template-columns: var(--recent-rounds-grid);
-  gap:8rpx;
-  padding:8rpx 4rpx;
-  background: var(--tf24-table-head-bg, #f8fafc);
-  color: var(--tf24-table-head-color, #475569);
-  font-size:24rpx;
-  font-weight:700;
-  border-radius:12rpx;
-}
-.rounds-head text,
-.round-item text{
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  text-align:center;
 }
-.round-item{
-  display:grid;
-  grid-template-columns: var(--recent-rounds-grid);
-  grid-gap:8rpx;
-  padding:8rpx 4rpx;
-  border-top:2rpx solid #eef2f7;
-}
-.r-time, .r-result, .r-timeMs {
-  font-size: 26rpx;
-  font-weight: 600;
-  color: #1e293b;
-}
-.r-cards{
-  font-size: 26rpx;
-  font-weight: 600;
-  color: #0f172a;
-  font-family: 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
-}
-.r-result.ok{ color:#16a34a; font-weight:700 }
-.r-result.fail{ color:#dc2626; font-weight:700 }
-.picker-trigger{ padding:8rpx 14rpx; background:#f1f5f9; border-radius:12rpx }
-.difficulty-heatmaps{
-  display:grid;
-  grid-template-rows:auto auto;
-  row-gap:12rpx;
-  margin-top:8rpx;
-  width:100%;
-}
-@media screen and (min-width: 960px) {
-  .difficulty-heatmaps{
-    max-width:960px;
-    margin-left:auto;
-    margin-right:auto;
-  }
-}
-.mistake-summary{ margin-top:16rpx; display:flex; flex-wrap:wrap; gap:24rpx; }
-.mistake-summary-item{ background:#f8fafc; border-radius:16rpx; padding:16rpx 24rpx; min-width:200rpx; display:flex; flex-direction:column; gap:8rpx; }
-.mistake-summary-label{ color:#6b7280; font-size:26rpx; }
-.mistake-summary-value{ color:#111827; font-size:36rpx; font-weight:700; }
-.mistake-controls{ display:flex; align-items:center; justify-content:flex-start; gap:16rpx; margin-top:16rpx; flex-wrap:wrap; }
-.mistake-filter{ display:flex; align-items:center; gap:12rpx; color:#374151; font-size:26rpx; }
-.mistake-table{ max-width:100%; overflow:hidden; }
-.mistake-grid{
-  display:grid;
-  grid-template-columns: minmax(200rpx, 1.6fr) repeat(4, minmax(120rpx, 1fr));
-  width:100%;
-}
-.mistake-head{
-  background: var(--tf24-table-head-bg, #f8fafc);
-  color: var(--tf24-table-head-color, #475569);
-  font-weight:700;
-  font-size:24rpx;
-}
-.mistake-body{ display:flex; flex-direction:column; width:100%; }
-.mistake-row{ border-top:1rpx solid #f1f5f9; font-size:26rpx; }
-.mistake-grid text{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  padding:10rpx 8rpx;
-  text-align:center;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.mistake-grid .mistake-th{ padding:12rpx 8rpx; }
-.mistake-cell.key,
-.mistake-th.key{
-  font-family: 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
-  color:#0f172a;
-}
-.mistake-cell.key:active{ opacity:.7; }
-.mistake-tip{ color:#6b7280; font-size:24rpx; flex:1; text-align:right; }
-.mistake-empty{ color:#64748b; font-size:26rpx; margin-top:8rpx; }
-.empty-tip{ color:#64748b; font-size:26rpx; margin-top:8rpx; }
 
-/* 表头排序：高亮当前列 */
-/* .th.active{ color:#0953e9; font-weight:800 } */
-.th.active{ color:#e5e7eb; background-color:#030300; font-weight:800 }
+.ok { color:#1f8750; font-weight:700; }
+.fail { color:#c84f4f; font-weight:700; }
 
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
+.user-list .claymorphism { margin-top:12rpx; }
 
+.mistake-summary { display:grid; grid-template-columns:repeat(2,1fr); gap:16rpx; }
+.mistake-summary-item { display:flex; flex-direction:column; align-items:center; gap:8rpx; }
+.mistake-summary-label { font-size:24rpx; color:var(--text-light); }
+.mistake-summary-value { font-size:36rpx; font-weight:800; color:var(--text-dark); }
+
+.mistake-controls { display:flex; justify-content:flex-end; }
+.mistake-grid { display:grid; grid-template-columns:1.5fr repeat(4,1fr); gap:12rpx; align-items:center; }
+.mistake-th { font-weight:700; color:var(--text-light); }
+.mistake-cell { text-align:center; font-size:26rpx; color:var(--text-dark); }
+
+.trend-chart { display:flex; flex-direction:column; gap:12rpx; }
+.trend-chart-inner { overflow:auto; }
+.trend-bars { display:flex; align-items:flex-end; }
+.trend-item { display:flex; align-items:flex-end; justify-content:center; }
+.bar { width:100%; border-radius:16rpx; background: var(--surface-dark); box-shadow: inset 4rpx 4rpx 8rpx var(--bg-dark), inset -4rpx -4rpx 8rpx #ffffff; display:flex; flex-direction:column-reverse; }
+.bar-success { background: var(--accent2); border-radius:16rpx 16rpx 0 0; }
+.bar-fail { background: var(--accent1); border-radius:0 0 16rpx 16rpx; }
+.trend-labels { display:flex; justify-content:space-between; color:var(--text-light); font-size:24rpx; }
+.trend-labels.rotate { writing-mode:vertical-rl; }
+
+.rounds { display:flex; flex-direction:column; gap:12rpx; }
+.rounds-head, .round-item { display:grid; grid-template-columns:1fr 1fr 1fr 2fr; gap:12rpx; align-items:center; }
+.rounds-head { font-weight:700; color:var(--text-light); }
+.round-item { background: var(--surface-light); border-radius:20rpx; padding:12rpx 16rpx; box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6); }
+.r-result.ok { color:#1f8750; }
+.r-result.fail { color:#c84f4f; }
+
+.mistake-table { margin-top:16rpx; }
+.mistake-head { font-weight:700; color:var(--text-light); }
+.mistake-row { background: var(--surface-light); border-radius:20rpx; padding:12rpx 16rpx; box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6); }
+.mistake-empty, .empty-tip { text-align:center; color:var(--text-light); padding:24rpx 0; }
+
+.seg { display:flex; background: var(--surface-light); border-radius:24rpx; padding:6rpx; box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6); }
+.seg-btn { flex:1; border:none; background:transparent; font-size:26rpx; padding:12rpx 18rpx; border-radius:18rpx; color:var(--text-light); }
+.seg-btn.active { background: var(--primary); color:#fff; box-shadow: 4rpx 4rpx 8rpx var(--primary-dark), -4rpx -4rpx 8rpx #c4eaff; }
+
+.picker-trigger { display:flex; align-items:center; justify-content:center; background: var(--surface-light); padding:16rpx; border-radius:24rpx; box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6); font-weight:700; color:var(--text-dark); }
+
+.mistake-filter { display:flex; align-items:center; gap:12rpx; font-size:26rpx; color:var(--text-dark); }
+.mistake-tip { font-size:24rpx; color:var(--text-light); }
+
+.speed-grid { display:grid; grid-template-columns:1.5fr repeat(5,1fr); gap:12rpx; }
+
+.floating-hint-layer { position:fixed; left:0; right:0; top:0; bottom:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999; }
+.floating-hint-layer.interactive { pointer-events:auto; }
+.floating-hint { background:rgba(67,78,90,0.9); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; font-size:28rpx; box-shadow:0 12rpx 24rpx rgba(0,0,0,0.25); }
 </style>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -1,24 +1,30 @@
 ﻿<template>
-  <view class="page" style="padding:24rpx; display:flex; flex-direction:column; gap:16rpx;"
+  <view class="page col" style="padding:24rpx; gap:16rpx;"
         @touchstart="edgeHandlers.handleTouchStart"
         @touchmove="edgeHandlers.handleTouchMove"
         @touchend="edgeHandlers.handleTouchEnd"
         @touchcancel="edgeHandlers.handleTouchCancel">
+    <UIHeader
+      :username="headerTitle"
+      @tap-avatar="refresh"
+      @tap-settings="showCreateHint"
+    />
+
     <view class="row" style="gap:12rpx; align-items:center;">
       <input v-model="newName" placeholder="新用户名称" class="input" />
-      <button class="btn btn-primary" @tap="create">添加</button>
+      <button class="clay-button-primary" @tap="create">添加</button>
     </view>
     <view class="list">
-      <view v-for="u in visibleUsers" :key="u.id" class="item card section" :class="{ active: u.id===users.currentId }">
+      <view v-for="u in visibleUsers" :key="u.id" class="item claymorphism card" :class="{ active: u.id===users.currentId }">
         <view class="user-left" @tap="choose(u.id)">
           <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
           <view v-else class="avatar" :style="{ backgroundColor: u.color || '#e2e8f0' }">{{ avatarText(u.name) }}</view>
           <view class="name">{{ u.name }}</view>
         </view>
         <view class="ops">
-          <button class="mini" @tap="rename(u)">改名</button>
-          <button class="mini" @tap="changeAvatar(u)">头像</button>
-          <button class="mini danger" @tap="remove(u.id)">删除</button>
+          <button class="mini clay-button" @tap="rename(u)">改名</button>
+          <button class="mini clay-button" @tap="changeAvatar(u)">头像</button>
+          <button class="mini clay-button danger" @tap="remove(u.id)">删除</button>
         </view>
       </view>
     </view>
@@ -31,14 +37,15 @@
       <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
     </view>
   </view>
-  <CustomTabBar />
-  
+  <BottomTab />
+
 </template>
 
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { onShow } from '@dcloudio/uni-app'
-import CustomTabBar from '../../components/CustomTabBar.vue'
+import UIHeader from '../../components/UIHeader.vue'
+import BottomTab from '../../components/BottomTab.vue'
 import { ensureInit, getUsers, addUser, renameUser, removeUser as rmUser, switchUser } from '../../utils/store.js'
 import { useFloatingHint } from '../../utils/hints.js'
 import { useEdgeExit } from '../../utils/edge-exit.js'
@@ -47,6 +54,7 @@ import { exitApp } from '../../utils/navigation.js'
 
 const users = ref({ list: [], currentId: '' })
 const newName = ref('')
+const headerTitle = computed(() => '用户管理')
 
 const { hintState, showHint, hideHint } = useFloatingHint()
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitPage() })
@@ -65,6 +73,7 @@ onShow(() => {
 
 function refresh(){ users.value = getUsers() }
 function create(){ addUser(newName.value.trim()||undefined); newName.value=''; refresh() }
+function showCreateHint(){ showHint('输入名称后点击添加', 1500) }
 function choose(id){
   switchUser(id)
   refresh()
@@ -157,21 +166,32 @@ function exitPage(){
 </script>
 
 <style scoped>
-.input{ flex:1; border:2rpx solid #e5e7eb; border-radius:12rpx; padding:16rpx; background:#fff }
-.list{ display:flex; flex-direction:column; gap:12rpx }
-.item{ display:flex; justify-content:space-between; align-items:center; padding:16rpx; border-radius:16rpx; border:2rpx solid #e5e7eb; background:#fff; box-shadow:0 6rpx 16rpx rgba(15,23,42,0.06) }
-.item.active{ border-color:#1677ff55; box-shadow:0 6rpx 16rpx rgba(22, 119, 255, 0.12) }
-.user-left{ display:flex; align-items:center; gap:12rpx }
-.avatar{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#0f172a; }
-.avatar-img{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0 }
-.name{ font-size:32rpx; font-weight:700 }
-.ops{ display:flex; gap:8rpx }
-.mini{ padding:8rpx 12rpx; border-radius:10rpx; background:#eef2f7; font-size:24rpx }
-.mini.danger{ background:#fee2e2; color:#b91c1c }
-.btn-primary{ background:#1677ff; color:#fff; border:none; padding:18rpx 24rpx; border-radius:12rpx }
-.page{ min-height:100vh; box-sizing:border-box; position:relative; }
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-</style>
+.row { display:flex; align-items:center; }
+.input {
+  flex:1;
+  border:2rpx solid rgba(255,255,255,0.5);
+  border-radius:24rpx;
+  padding:18rpx 24rpx;
+  background: var(--surface-light);
+  box-shadow: inset 4rpx 4rpx 8rpx rgba(0,0,0,0.05), inset -4rpx -4rpx 8rpx rgba(255,255,255,0.6);
+  font-size:28rpx;
+  color:var(--text-dark);
+}
 
+.list { display:flex; flex-direction:column; gap:16rpx; }
+.item { display:flex; justify-content:space-between; align-items:center; padding:18rpx; border-radius:24rpx; transition:box-shadow .2s ease; }
+.item.active { box-shadow: 8rpx 8rpx 16rpx rgba(100,162,197,0.25), -8rpx -8rpx 16rpx rgba(255,255,255,0.8); }
+.user-left { display:flex; align-items:center; gap:16rpx; }
+.avatar, .avatar-img { width:88rpx; height:88rpx; border-radius:9999rpx; }
+.avatar { display:flex; align-items:center; justify-content:center; font-size:34rpx; font-weight:700; color:#fff; background: var(--primary-dark); }
+.avatar-img { background: var(--surface-dark); }
+.name { font-size:32rpx; font-weight:700; color:var(--text-dark); }
+
+.ops { display:flex; gap:12rpx; }
+.mini { padding:12rpx 20rpx; border-radius:20rpx; font-size:26rpx; color:var(--text-dark); }
+.mini.danger { color:#c84f4f; }
+
+.floating-hint-layer { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999; }
+.floating-hint-layer.interactive { pointer-events:auto; }
+.floating-hint { background:rgba(67,78,90,0.9); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; font-size:28rpx; box-shadow:0 12rpx 24rpx rgba(0,0,0,0.25); }
+</style>


### PR DESCRIPTION
## Summary
- introduce shared claymorphism theme tokens and utility classes
- add reusable UIHeader, BottomTab, and supporting components for clay layout
- restyle index, login, stats, and user pages to adopt the new claymorphism UI modules

## Testing
- not run (uni-app project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d013bce4b88323b340d3bd2c3cd6d7