### PR TITLE
Add unified login flows

### DIFF
--- a/docs/account_system.md
+++ b/docs/account_system.md
@@ -1,0 +1,173 @@
+# 账号体系与登录改造说明
+
+本文件描述了微信账号 + 本机多账号的统一实现，包括云函数、数据库 Schema 与前端页面改造要点。
+
+## 1. 云函数 `login`（uniCloud/cloudfunctions/login/index.js）
+
+- 入口通过 `event.scene` 区分三种流程：
+  - `mp-weixin`：`wx.login` → `code` → `fetchWeixinSession`，使用 `openid`/`unionid` 创建或更新微信账号。
+  - `app`：依赖 `deviceId` + `user_id` 进行本机普通账号登录；若未传 `user_id` 则直接创建一个新的普通账号（昵称来源于 `extra.nickname` 或默认值）。
+  - `upgrade`：把本机普通账号升级为微信账号，或与已有微信账号合并（`score` 取最大、`coins` 求和）。
+- 所有场景返回 `{ token, user }`，其中 `token = createToken({ user_id, account_type })`，`user` 会去掉 `device_id` 并补全 `stats`。
+- 微信凭证读取优先级：`process.env.WX_APPID/WX_SECRET` → `process.env.MP_WEIXIN_*` → `uniCloud.getConfig().weixin`。
+- 关键辅助函数：
+  - `fetchWeixinSession(code)`：调用 `https://api.weixin.qq.com/sns/jscode2session`。
+  - `handleMpWeixin` / `handleApp` / `handleUpgrade`：按 PRD 拆分逻辑。
+  - `mergeStats`、`ensureStats`：确保统计字段可被安全合并。
+
+## 2. 数据库 `user` Schema（uniCloud/database/user.schema.json）
+
+- 字段核心：`account_type`（`weixin|local`）、`openid`、`device_id`、`stats` 等。
+- `openid` 设置唯一索引（允许为空）。
+- 允许重复昵称；普通账号必须存 `device_id` 以限制本机使用。
+- `merged_to`/`merged_at` 字段用于记录升级后本地账号的归属。
+
+## 3. 前端页面改造指引
+
+### 3.1 登录方式选择页（`pages/login/index.vue`）
+
+```vue
+<template>
+  <view class="login-entry">
+    <!-- #ifdef MP-WEIXIN -->
+    <button @tap="wxLogin">微信登录</button>
+    <!-- #endif -->
+    <button @tap="gotoLocalAccounts">普通账号登录</button>
+  </view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const loading = ref(false)
+
+function gotoLocalAccounts () {
+  uni.navigateTo({ url: '/pages/user/local-list' })
+}
+
+async function wxLogin () {
+  loading.value = true
+  try {
+    const { code } = await uni.login({ provider: 'weixin' })
+    const res = await uniCloud.callFunction({
+      name: 'login',
+      data: { scene: 'mp-weixin', code, platform: 'mp-weixin' }
+    })
+    handleLoginSuccess(res.result)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+```
+
+### 3.2 普通账号列表页（`pages/user/local-list.vue`）
+
+- 本地缓存：`const localAccounts = ref(uni.getStorageSync('local_accounts') || [])`。
+- 列表项结构：`{ user_id, nickname, avatar_url, created_at }`，点击后按如下流程登录：
+
+```js
+async function loginLocal(account) {
+  const deviceId = await resolveDeviceId()
+  const { result } = await uniCloud.callFunction({
+    name: 'login',
+    data: { scene: 'app', deviceId, user_id: account.user_id, platform: currentPlatformTag }
+  })
+  persistSession(result)
+}
+```
+
+- `resolveDeviceId`：
+  - `#ifdef APP-PLUS` 使用 `plus.device.uuid`。
+  - `#ifdef MP-WEIXIN` 兜底可使用 `uni.getStorageSync('tf24_device_id')`，无则随机生成 UUID 并写入 storage。
+- 新建按钮跳转到“普通账号创建页”。
+- 长按操作：
+  - `renameLocalAccount(account)`：更新 `local_accounts` 与后端（可复用 `user` 云对象）。
+  - `removeLocalAccount(account)`：本地删除后可调用后端标记。
+
+### 3.3 普通账号创建页（`pages/user/local-create.vue`）
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const nickname = ref('')
+const avatarUrl = ref('')
+
+async function submit () {
+  if (!nickname.value) {
+    uni.showToast({ title: '请输入昵称', icon: 'none' })
+    return
+  }
+  const deviceId = await resolveDeviceId()
+  const { result } = await uniCloud.callFunction({
+    name: 'login',
+    data: {
+      scene: 'app',
+      deviceId,
+      platform: currentPlatformTag,
+      extra: { nickname: nickname.value, avatar_url: avatarUrl.value }
+    }
+  })
+  const list = uni.getStorageSync('local_accounts') || []
+  list.push({
+    user_id: result.user._id,
+    nickname: result.user.nickname,
+    avatar_url: result.user.avatar_url,
+    created_at: Date.now()
+  })
+  uni.setStorageSync('local_accounts', list)
+  persistSession(result)
+  uni.reLaunch({ url: '/pages/index/index' })
+}
+</script>
+```
+
+### 3.4 升级为微信账号（`pages/user/profile.vue`）
+
+```js
+async function upgradeToWeixin () {
+  if (currentUser.account_type !== 'local') return
+  const { code } = await uni.login({ provider: 'weixin' })
+  const { result } = await uniCloud.callFunction({
+    name: 'login',
+    data: { scene: 'upgrade', code, user_id: currentUser._id, platform: 'mp-weixin' }
+  })
+  persistSession(result)
+  syncLocalAccountAfterUpgrade(currentUser._id, result.user._id)
+}
+```
+
+- `syncLocalAccountAfterUpgrade`：可以删除或标记旧的本地账号，提示“已升级为微信账号，可跨设备登录”。
+
+## 4. 账号体系说明
+
+| 项目 | 微信账号 | 普通账号 |
+| --- | --- | --- |
+| account_type | `weixin` | `local` |
+| 唯一标识 | `openid`/`unionid` | `_id` + `device_id` |
+| 登录范围 | 跨设备 | 仅创建设备 |
+| 创建方式 | 小程序 `wx.login` | App/小程序内“新建普通账号” |
+| 升级 | 不需要 | 可升级到微信账号，数据合并 |
+
+- 升级时：`score = max(local.score, weixin.score)`、`coins = local.coins + weixin.coins`。
+- 本地列表仅保存基本展示信息，真实数据仍以云端为准。
+
+## 5. 调试与配置
+
+- **微信凭证**：开发阶段可在 `uniCloud/cloudfunctions/login/index.js` 使用的环境变量中临时写死：
+  - HBuilderX 本地调试：在 `uniCloud-aliyun/cloudfunctions/login/config.json`（若有）或 `uniCloud/cloudfunctions/login/config.json` 中写入 `"WX_APPID"`、`"WX_SECRET"`。
+  - 也可在 CI/部署环境下通过 `uniCloud env` 设置 `WX_APPID`、`WX_SECRET`，不建议在代码库中硬编码正式密钥。
+- **manifest.json**：
+  - App 端需启用 `uniCloud`、`push`、`secure HTTPS` 权限，并确保 `APP-PLUS` 平台可读取 `plus.device.uuid`。
+  - 微信小程序勾选“需要用户信息”、“使用云函数”并填写 `AppID`。
+- **小程序后台**：
+  - 业务域名需包含 `https://api.weixin.qq.com`（默认已允许）。
+  - 在“开发管理 → 开发设置”中配置云开发环境、上传合法的 request 域名（若使用自定义域名访问 uniCloud HTTP 服务）。
+  - 需要在“开发管理 → 服务器域名”中添加 `https://api.weixin.qq.com` 以及 `https://<your-unicloud-endpoint>`（若使用 HTTP 调用）。
+
+## 6. 其他建议
+
+- `local_accounts` 建议与登录状态联动，若云端账号被合并/删除，可在下一次登录失败时清理本地缓存。
+- 若后续需要手机号码、邮箱等登录方式，可在 `account_type` 基础上扩展 `credential` 字段，并在 `login` 云函数中新增 `scene`。
+- 可在 `docs/uniCloud_rework.md` 的基础上继续扩展更多云函数或页面示例。

--- a/uniCloud/cloudfunctions/common/auth.js
+++ b/uniCloud/cloudfunctions/common/auth.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const crypto = require('crypto')
+
+const TOKEN_SECRET = process.env.TF24_TOKEN_SECRET || process.env.TOKEN_SECRET || 'CHANGE_ME_DEV_ONLY'
+const TOKEN_TTL = Number(process.env.TF24_TOKEN_TTL || 60 * 60 * 24 * 30) * 1000 // default 30 days
+
+function base64UrlEncode(str) {
+  return Buffer.from(str)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+function base64UrlDecode(str) {
+  const pad = 4 - (str.length % 4 || 4)
+  const normalized = str.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(pad === 4 ? 0 : pad)
+  return Buffer.from(normalized, 'base64').toString()
+}
+
+function createToken(payload = {}) {
+  const now = Date.now()
+  const header = { alg: 'HS256', typ: 'JWT' }
+  const body = {
+    ...payload,
+    iat: Math.floor(now / 1000),
+    exp: Math.floor((now + TOKEN_TTL) / 1000)
+  }
+  const segments = [base64UrlEncode(JSON.stringify(header)), base64UrlEncode(JSON.stringify(body))]
+  const signature = crypto
+    .createHmac('sha256', TOKEN_SECRET)
+    .update(segments.join('.'))
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+  return `${segments.join('.')}.${signature}`
+}
+
+function verifyToken(token = '') {
+  if (!token) return null
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  const [headerSeg, payloadSeg, signature] = parts
+  const expectedSig = crypto
+    .createHmac('sha256', TOKEN_SECRET)
+    .update(`${headerSeg}.${payloadSeg}`)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+  if (expectedSig !== signature) return null
+  try {
+    const payload = JSON.parse(base64UrlDecode(payloadSeg))
+    if (payload.exp && payload.exp * 1000 < Date.now()) {
+      return null
+    }
+    return payload
+  } catch (err) {
+    return null
+  }
+}
+
+module.exports = {
+  createToken,
+  verifyToken
+}

--- a/uniCloud/cloudfunctions/login/index.js
+++ b/uniCloud/cloudfunctions/login/index.js
@@ -1,0 +1,273 @@
+'use strict'
+
+const db = uniCloud.database()
+const usersCollection = db.collection('user')
+const dbCmd = db.command
+const { createToken } = require('../common/auth')
+
+const DEFAULT_STATS = { score: 0, coins: 0 }
+
+module.exports = async (event = {}, context) => {
+  const { scene } = event
+  if (!scene) {
+    throw new Error('scene is required')
+  }
+
+  if (scene === 'mp-weixin') {
+    return handleMpWeixin(event)
+  }
+
+  if (scene === 'app') {
+    return handleApp(event)
+  }
+
+  if (scene === 'upgrade') {
+    return handleUpgrade(event)
+  }
+
+  throw new Error(`unsupported scene: ${scene}`)
+}
+
+async function handleMpWeixin(event) {
+  const { code, platform = 'mp-weixin' } = event
+  if (!code) {
+    throw new Error('code is required for mp-weixin login')
+  }
+
+  const session = await fetchWeixinSession(code)
+  const { openid, unionid } = session
+  if (!openid) {
+    throw new Error('failed to obtain openid from wx jscode2session')
+  }
+
+  const now = Date.now()
+  let user = await usersCollection.where({ openid }).get().then(transformFirst)
+
+  if (!user) {
+    const doc = {
+      account_type: 'weixin',
+      openid,
+      unionid,
+      device_id: '',
+      nickname: '',
+      avatar_url: '',
+      platforms: [platform],
+      stats: { ...DEFAULT_STATS },
+      created_at: now,
+      last_login_at: now
+    }
+    const addRes = await usersCollection.add(doc)
+    user = { ...doc, _id: addRes.id }
+  } else {
+    const updatePayload = {
+      last_login_at: now,
+      unionid: unionid || user.unionid,
+      ...platformUpdate(platform)
+    }
+    await usersCollection.doc(user._id).update(updatePayload)
+    user = applyPlatform({ ...user, last_login_at: now, unionid: unionid || user.unionid }, platform)
+  }
+
+  const token = createToken({ user_id: user._id, account_type: 'weixin' })
+  return { token, user: sanitizeUser(user) }
+}
+
+async function handleApp(event) {
+  const { deviceId, user_id, platform = 'app-android', extra = {} } = event
+  if (!deviceId) {
+    throw new Error('deviceId is required for app login')
+  }
+
+  const now = Date.now()
+  let user
+
+  if (user_id) {
+    user = await getUserById(user_id)
+    if (!user) {
+      throw new Error('user not found')
+    }
+    if (user.account_type !== 'local') {
+      throw new Error('only local accounts can be used via app scene user_id login')
+    }
+    if (user.device_id !== deviceId) {
+      throw new Error('此账号仅限本机使用')
+    }
+
+    await usersCollection.doc(user._id).update({
+      last_login_at: now,
+      ...platformUpdate(platform)
+    })
+    user = applyPlatform({ ...user, last_login_at: now }, platform)
+  } else {
+    const nickname = extra.nickname || generateDefaultNickname()
+    const avatar_url = extra.avatar_url || ''
+    const doc = {
+      account_type: 'local',
+      device_id: deviceId,
+      nickname,
+      avatar_url,
+      platforms: [platform],
+      stats: { ...DEFAULT_STATS },
+      created_at: now,
+      last_login_at: now
+    }
+    const addRes = await usersCollection.add(doc)
+    user = { ...doc, _id: addRes.id }
+  }
+
+  const token = createToken({ user_id: user._id, account_type: user.account_type })
+  return { token, user: sanitizeUser(user) }
+}
+
+async function handleUpgrade(event) {
+  const { code, user_id, platform = 'mp-weixin' } = event
+  if (!code) {
+    throw new Error('code is required for upgrade')
+  }
+  if (!user_id) {
+    throw new Error('user_id is required for upgrade')
+  }
+
+  const session = await fetchWeixinSession(code)
+  const { openid, unionid } = session
+  if (!openid) {
+    throw new Error('failed to obtain openid for upgrade')
+  }
+
+  const localUser = await getUserById(user_id)
+  if (!localUser) {
+    throw new Error('local user not found')
+  }
+  if (localUser.account_type !== 'local') {
+    throw new Error('only local accounts can be upgraded')
+  }
+
+  const now = Date.now()
+  let targetUser = await usersCollection.where({ openid }).get().then(transformFirst)
+
+  if (!targetUser) {
+    await usersCollection.doc(localUser._id).update({
+      account_type: 'weixin',
+      openid,
+      unionid,
+      device_id: '',
+      last_login_at: now,
+      ...platformUpdate(platform)
+    })
+    targetUser = applyPlatform(
+      {
+        ...localUser,
+        account_type: 'weixin',
+        openid,
+        unionid,
+        device_id: '',
+        last_login_at: now
+      },
+      platform
+    )
+  } else {
+    const mergedStats = mergeStats(localUser.stats, targetUser.stats)
+    await usersCollection.doc(targetUser._id).update({
+      stats: mergedStats,
+      last_login_at: now,
+      unionid: unionid || targetUser.unionid,
+      ...platformUpdate(platform)
+    })
+    await usersCollection.doc(localUser._id).update({ merged_to: targetUser._id, merged_at: now })
+    targetUser = applyPlatform(
+      {
+        ...targetUser,
+        stats: mergedStats,
+        last_login_at: now,
+        unionid: unionid || targetUser.unionid
+      },
+      platform
+    )
+  }
+
+  const token = createToken({ user_id: targetUser._id, account_type: 'weixin' })
+  return { token, user: sanitizeUser(targetUser) }
+}
+
+async function fetchWeixinSession(code) {
+  const { appid, secret } = loadWeixinConfig()
+  if (!appid || !secret) {
+    throw new Error('WX_APPID/WX_SECRET not configured')
+  }
+
+  const url =
+    'https://api.weixin.qq.com/sns/jscode2session?appid=' +
+    encodeURIComponent(appid) +
+    '&secret=' +
+    encodeURIComponent(secret) +
+    '&js_code=' +
+    encodeURIComponent(code) +
+    '&grant_type=authorization_code'
+
+  const res = await uniCloud.httpclient.request(url, { dataType: 'json', method: 'GET', timeout: 5000 })
+  if (res.status !== 200 || !res.data) {
+    throw new Error('failed to call jscode2session')
+  }
+  if (res.data.errcode) {
+    throw new Error(`jscode2session error: ${res.data.errmsg || res.data.errcode}`)
+  }
+  return res.data
+}
+
+function loadWeixinConfig() {
+  const config = uniCloud.getConfig && uniCloud.getConfig()
+  const mpConfig = (config && (config.mp || config.weixin)) || {}
+  return {
+    appid: process.env.WX_APPID || process.env.MP_WEIXIN_APPID || mpConfig.appid || (mpConfig.mp && mpConfig.mp.appid),
+    secret: process.env.WX_SECRET || process.env.MP_WEIXIN_SECRET || mpConfig.secret || (mpConfig.mp && mpConfig.mp.secret)
+  }
+}
+
+async function getUserById(userId) {
+  return usersCollection.doc(userId).get().then(transformFirst)
+}
+
+function transformFirst(res) {
+  if (!res || !res.data || !res.data.length) return null
+  return res.data[0]
+}
+
+function applyPlatform(user, platform) {
+  if (!platform) return user
+  const platforms = Array.isArray(user.platforms) ? [...user.platforms] : []
+  if (!platforms.includes(platform)) {
+    platforms.push(platform)
+  }
+  return { ...user, platforms }
+}
+
+function platformUpdate(platform) {
+  if (!platform) return {}
+  return { platforms: dbCmd.addToSet(platform) }
+}
+
+function sanitizeUser(user) {
+  if (!user) return user
+  const { device_id, ...rest } = user
+  return { ...rest, stats: ensureStats(rest.stats) }
+}
+
+function mergeStats(localStats = {}, wechatStats = {}) {
+  const local = ensureStats(localStats)
+  const remote = ensureStats(wechatStats)
+  return {
+    score: Math.max(local.score, remote.score),
+    coins: local.coins + remote.coins
+  }
+}
+
+function generateDefaultNickname() {
+  return '玩家' + String(Date.now()).slice(-4)
+}
+
+function ensureStats(stats = {}) {
+  return {
+    score: Number(stats.score) || 0,
+    coins: Number(stats.coins) || 0
+  }
+}

--- a/uniCloud/database/user.schema.json
+++ b/uniCloud/database/user.schema.json
@@ -1,0 +1,80 @@
+{
+  "bsonType": "object",
+  "required": ["account_type", "created_at"],
+  "properties": {
+    "account_type": {
+      "bsonType": "string",
+      "enum": ["weixin", "local"],
+      "description": "账号类型：微信 / 本机普通"
+    },
+    "openid": {
+      "bsonType": "string",
+      "description": "微信 openid"
+    },
+    "unionid": {
+      "bsonType": "string",
+      "description": "微信 unionid（可空）"
+    },
+    "device_id": {
+      "bsonType": "string",
+      "description": "普通账号绑定的设备 ID"
+    },
+    "nickname": {
+      "bsonType": "string",
+      "description": "昵称，可重复",
+      "default": "玩家"
+    },
+    "avatar_url": {
+      "bsonType": "string",
+      "description": "头像 URL"
+    },
+    "platforms": {
+      "bsonType": "array",
+      "items": { "bsonType": "string" },
+      "description": "登录过的平台列表"
+    },
+    "created_at": {
+      "bsonType": "long",
+      "description": "注册时间（ms）"
+    },
+    "last_login_at": {
+      "bsonType": "long",
+      "description": "最近登录时间（ms）"
+    },
+    "stats": {
+      "bsonType": "object",
+      "properties": {
+        "score": { "bsonType": "double", "default": 0 },
+        "coins": { "bsonType": "double", "default": 0 }
+      },
+      "description": "游戏统计数据"
+    },
+    "merged_to": {
+      "bsonType": "string",
+      "description": "升级/合并后指向的新账号"
+    },
+    "merged_at": {
+      "bsonType": "long",
+      "description": "合并时间"
+    }
+  },
+  "indexes": [
+    {
+      "name": "openid_unique",
+      "unique": true,
+      "fields": {
+        "openid": 1
+      },
+      "partialFilterExpression": {
+        "openid": { "$exists": true }
+      }
+    },
+    {
+      "name": "device_type_index",
+      "fields": {
+        "device_id": 1,
+        "account_type": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a uniCloud login function that supports WeChat, local app, and upgrade scenes with token issuance
- provide a matching user collection schema and token helper module
- document the new account system along with front-end integration guidance

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193503b1088323b06e1878cc08c70b)