### PR TITLE
Add config-center fallback for login

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -1,11 +1,13 @@
 <script>
 import { ensureUserAvatars } from './utils/avatar.js'
 import { scheduleTabWarmup } from './utils/tab-cache.js'
+import { ensureAutoLogin } from './utils/auth.js'
 
 export default {
   onLaunch() {
     try { ensureUserAvatars && ensureUserAvatars().catch(() => {}) } catch (_) {}
     try { scheduleTabWarmup({ immediate: true }) } catch (_) {}
+    ensureAutoLogin()
     try {
       // 仅 App 端支持预加载，H5 忽略
       // #ifdef APP-PLUS

--- a/docs/account-system.md
+++ b/docs/account-system.md
@@ -1,0 +1,74 @@
+# 账号体系与登录改造说明
+
+## 账号类型
+
+| 账号类型 | 唯一标识 | 特性 |
+| --- | --- | --- |
+| 微信账号 (`weixin`) | `openid` + 可选 `unionid` | 可跨设备登录，支持在任意微信小程序实例同步数据 |
+| 本机普通账号 (`local`) | `_id` + `device_id` | 可在同一设备创建多个，禁止跨设备登录，可随时升级为微信账号 |
+
+`user` 集合字段：
+
+```jsonc
+{
+  "_id": "string",          // user_id
+  "account_type": "weixin | local",
+  "openid": "string",
+  "unionid": "string",
+  "device_id": "string",
+  "nickname": "string",
+  "avatar_url": "string",
+  "platforms": ["mp-weixin", "app-android", "app-ios", "app-harmony"],
+  "created_at": 0,
+  "last_login_at": 0,
+  "stats": { "score": 0, "coins": 0 },
+  "merged_to": "string"
+}
+```
+
+## 云函数 `login`
+
+- `scene = 'mp-weixin'`：接收 `code`，走 `jscode2session`，按 `openid` 查找/创建账号。
+- `scene = 'app'`：带 `deviceId` + `user_id` 登录普通账号；当 `create = true` 时创建新账号并绑定设备（保持所有注册/登录分支在同一云函数内，便于复用 token 逻辑）。
+- `scene = 'upgrade'`：普通账号 + `code` 升级/合并为微信账号。
+- 所有场景返回 `{ token, user }`，token 由 `common/auth` 生成，user 已去除敏感字段并且 `errCode/errMsg` 结构化返回错误，方便前端识别。
+
+## 配置 / WX_APPID · WX_SECRET
+
+- `login/index.js` 先读取 `process.env.WX_APPID/WX_SECRET`，若未提供会自动回退到 `uni-config-center`（例如 `config/uni-id` 中的 `mp-weixin` 节点）。
+- 推荐在 `uniCloud/cloudfunctions/common/uni-config-center/uni-id/config.json`（示例）或云函数环境变量中配置密钥；调试期可在云函数测试面板临时写死。
+- 如果两者都未配置，将在 `fetchWeixinSession` 阶段抛出“请在环境变量或 uni-config-center 中配置”提示，避免上线后因为遗漏导致静默失败。
+
+## device_id 与本机账号
+
+- `utils/local-account.ensureDeviceId()` 在 App 端优先使用 `plus.device.uuid`，小程序端生成一个本地 UUID 并持久化到 `uni.setStorageSync('tf24_device_id_v1')`。
+- 清理小程序缓存会丢失该 device_id，相当于普通账号无法再登录。PRD 允许这种行为（提示用户升级为微信账号以跨设备/恢复）。
+- 本机普通账号创建信息也缓存在 `local_accounts`，支持多账号但都受同一个 `device_id` 限制。
+
+## 普通账号删除策略
+
+- 列表页长按仅移除本地缓存（方案 A），云端记录保留以便后续升级或手动恢复。
+- 如需联动删除，可新增二次确认入口调用新的云函数；目前默认策略更安全、可避免误删导致云端数据不可追溯。
+
+调试时可在 HBuilderX → 运行配置中设置 `WX_APPID`、`WX_SECRET` 环境变量，或在云函数的环境变量界面临时写死测试值。
+
+## 前端页面与流程
+
+1. **登录方式选择（`pages/login/index`）**：提供“微信登录”“普通账号”入口。
+2. **普通账号列表（`pages/local-account/list`）**：读取 `local_accounts`，可选择登录/长按删除。
+3. **普通账号创建（`pages/local-account/create`）**：输入昵称、可选头像，调用 `login(scene='app', create:true)` 创建账号。
+4. **升级入口（`pages/user/index`）**：普通账号在微信端可触发 `scene='upgrade'`，升级后即可跨设备登录。
+
+`utils/local-account.js` 统一管理 `device_id` 和本机账号缓存，`utils/auth.js` 封装云函数调用、token 存储与平台判定。
+
+## manifest / 小程序后台配置
+
+- manifest.json：保持 `uniCloud` 服务空间绑定，并为 mp-weixin 勾选“微信登录”权限。
+- 微信小程序后台：在“开发管理→开发设置”中将 `request` 白名单加入 `https://api.weixin.qq.com`，并配置服务器域名。
+- App 打包：在 `manifest.json` → `App模块配置` 中启用 `uniCloud`、`uni.login` 所需模块。
+
+## WX_APPID / WX_SECRET
+
+- 本地调试可在 `uniCloud` 云函数测试面板、`uniCloud/cloudfunctions/login/index.js` 中通过 `process.env.WX_APPID`、`process.env.WX_SECRET` 读取。
+- 临时测试可在 `uniCloud` 控制台 → `环境变量` 中添加 `WX_APPID` / `WX_SECRET`。
+- 请勿将真实密钥提交至仓库。

--- a/docs/uniCloud_rework.md
+++ b/docs/uniCloud_rework.md
@@ -1,0 +1,209 @@
+# uniCloud 多账号体系与登录改造说明
+
+本文记录当前仓库中“微信账号 + 本机普通账号”双轨并行的账号体系、云函数实现与前端集成方式，便于后续扩展/联调。
+
+## 1. 总体架构
+- **前端（uni-app）**：所有端统一使用 `utils/auth.js`、`utils/local-account.js` 维护 token、设备 ID 及本机普通账号缓存；页面通过条件编译接入不同的登录流程。
+- **后端（uniCloud 云函数 + 云数据库）**：`login` 云函数提供三种 `scene`：`mp-weixin`、`app`（普通账号）与 `upgrade`（普通账号升级为微信账号）；`common/auth.js` 输出 HMAC token；`user`/`game` 云函数在业务层复用 token 鉴权。
+- **数据层**：统一 `user` 表，使用 `_id` 作为 `user_id`；通过 `account_type`（`weixin | local`）区分微信账号与普通账号，并保存 `device_id`、`openid` 等字段。
+
+```
+uni-app（mp-weixin / app-android / app-ios / app-harmony）
+   │  utils/auth.js 负责调用登录云函数、缓存 token
+   ▼
+uniCloud/cloudfunctions
+   ├─ common/auth.js         # createToken / verifyToken
+   ├─ login/index.js         # scene=mp-weixin / app / upgrade
+   ├─ user/index.js          # 资料修改、头像昵称同步
+   └─ game/index.js          # 业务数据，需要先校验 token
+```
+
+## 2. 账号类型与能力
+| 账号类型 | 唯一标识 | 支持平台 | 能力 | 关键字段 |
+| --- | --- | --- | --- | --- |
+| 微信账号 (`account_type = 'weixin'`) | `openid`（必填）+ `unionid`（可选） | mp-weixin + 任意安装了微信的 App | 跨设备登录、可同步昵称头像、可承载升级后的数据 | `_id`、`openid`、`platforms`、`stats` |
+| 普通账号 (`account_type = 'local'`) | `_id`（云端生成）+ `device_id` | mp-weixin（无需 wx.login）与 App 端 | 本机多账号切换，禁止跨设备；可在任意端创建/登录，但必须上传当前 `device_id` | `_id`、`device_id`、`nickname`、`stats` |
+| 升级账号 | 普通账号升级后即成为微信账号 | 与微信账号一致 | 普通账号的统计与进度合并到微信账号；原普通账号标记 `merged_to` | `merged_to`、`merged_at` |
+
+> **升级流程**：在本机选定一个普通账号 → 小程序调用 `wx.login` → `login(scene='upgrade')` 校验 `device_id` + `user_id`，若该微信尚无账号则直接把普通账号转型；若已有微信账号，则调用 `mergeStats` 合并数据，并把普通账号标记为 `merged`。
+
+## 3. `user` 集合 schema
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `_id` | string | 即 `user_id`，云端生成，前端也以此做本地缓存键 |
+| `account_type` | string | `weixin` / `local` |
+| `openid` | string | 微信账号的 openid，普通账号为空 |
+| `unionid` | string | 微信生态唯一标识，可为空 |
+| `device_id` | string | 普通账号绑定的设备 ID（App 端取 `plus.device.uuid`，小程序端取随机 UUID） |
+| `nickname` | string | 可重复；普通账号默认“普通账号” |
+| `avatar_url` | string | 头像 URL，可为空 |
+| `platforms` | array | 已登录过的平台列表（`mp-weixin`/`app-android`/...） |
+| `stats.score` | number | 游戏分数（示例字段） |
+| `stats.coins` | number | 虚拟币（示例字段） |
+| `created_at` | long | 创建时间戳 |
+| `last_login_at` | long | 最近登录时间 |
+| `merged_to` | string | 被合并到的微信账号 `_id`，仅升级场景产生 |
+| `merged_at` | long | 升级完成时间 |
+
+`uniCloud/database/user.schema.json`（已更新）示例：
+```json
+{
+  "bsonType": "object",
+  "required": ["account_type", "nickname"],
+  "properties": {
+    "_id": { "bsonType": "string", "description": "user_id，全局唯一" },
+    "account_type": { "enum": ["weixin", "local"], "description": "账号类型" },
+    "openid": { "bsonType": "string" },
+    "unionid": { "bsonType": "string" },
+    "device_id": { "bsonType": "string", "description": "普通账号绑定的设备ID" },
+    "nickname": { "bsonType": "string" },
+    "avatar_url": { "bsonType": "string" },
+    "gender": { "bsonType": "int" },
+    "platforms": { "bsonType": "array", "items": { "bsonType": "string" } },
+    "stats": {
+      "bsonType": "object",
+      "properties": {
+        "score": { "bsonType": "int" },
+        "coins": { "bsonType": "int" }
+      }
+    },
+    "created_at": { "bsonType": "long" },
+    "last_login_at": { "bsonType": "long" },
+    "updated_at": { "bsonType": "long" },
+    "merged_to": { "bsonType": "string" },
+    "merged_at": { "bsonType": "long" }
+  },
+  "indexes": [
+    { "name": "idx_openid", "unique": true, "fields": { "openid": 1 } },
+    { "name": "idx_device", "fields": { "device_id": 1 } },
+    { "name": "idx_account_type", "fields": { "account_type": 1 } }
+  ]
+}
+```
+
+## 4. 登录云函数 `uniCloud/cloudfunctions/login/index.js`
+关键逻辑：
+- `handleMpWeixin`：调用 `fetchWeixinSession` 获取 openid/unionid → 查找/创建 `account_type='weixin'` 的用户 → 更新 `platforms` + `last_login_at` → 返回 token。
+- `handleApp`：
+  - 带 `user_id`：校验 `account_type === 'local'` 且 `device_id` 一致；更新 `last_login_at`。
+  - `extra.create=true`：创建一个新普通账号（云端生成 `_id`），写入本机 `device_id`，昵称/头像来自 `extra`。
+- `handleUpgrade`：
+  1. `wx.login` → `code` → openid；
+  2. 根据 `user_id` 读取普通账号并校验 `device_id`；
+  3. 若 openid 未注册 → 直接把该普通账号升级成微信账号；
+  4. 若已有微信账号 → `mergeStats`（`score` 取最大、`coins` 累加），并把普通账号记录 `merged_to`。
+
+文件中提供了 `ensurePlatforms`、`normalizeStats`、`mergeStats` 等工具函数，最终均通过 `auth.createToken(user)` 产出 token，返回 `{ token, user: sanitizeUser(user) }`。
+
+> **调试 WX_APPID/WX_SECRET**：在 uniCloud 云函数配置环境变量或 `.env.local`（HBuilderX 云函数运行配置）中写死 `WX_APPID`、`WX_SECRET`，并在微信小程序后台把云函数域名加入合法域名。
+
+## 5. 前端辅助模块
+### 5.1 `utils/local-account.js`
+封装了 `listLocalAccounts`、`upsertLocalAccount`、`removeLocalAccount`、`markAccountUpgraded` 等方法，统一把本机普通账号缓存到 `tf24_local_accounts_v1`：
+```js
+// 缓存结构（local storage）
+[
+  { user_id, nickname, avatar_url, created_at, last_login_at, upgraded }
+]
+```
+
+### 5.2 `utils/auth.js`
+新增方法：
+- `getDeviceId()`：App 端优先取 `plus.device.uuid`，否则生成随机 UUID 并落地 `tf24_device_id`。
+- `wxLogin()`：小程序端 `wx.login` → `login(scene='mp-weixin')`。
+- `createLocalAccount({ nickname, avatar_url })`：`login(scene='app', extra.create=true)`，创建普通账号并写入本地缓存。
+- `loginLocalAccount(userId)` / `appLogin(userId)`：携带 `deviceId` 登录已存在的普通账号。
+- `upgradeLocalAccount(userId)`：小程序端发起升级，成功后在本地标记 `upgraded` 并刷新 token。
+- `getLocalAccounts()`：返回 `local_accounts` 列表供普通账号列表页展示。
+
+> `ensureAutoLogin()` 仅在存在本地 token 时复用 Session，不再自动帮用户决定登录方式，避免误触发微信登录或错误的普通账号绑定。
+
+## 6. 页面改造建议
+### 6.1 登录方式选择页（`pages/login/index.vue` 可复用）
+```vue
+<template>
+  <view class="login-choice">
+    <button class="wx" @tap="doWxLogin" v-if="isMpWeixin">微信登录</button>
+    <button class="local" @tap="goLocalList">普通账号登录</button>
+  </view>
+</template>
+<script setup>
+import { wxLogin } from '@/utils/auth.js'
+const isMpWeixin = process.env.UNI_PLATFORM === 'mp-weixin'
+async function doWxLogin() {
+  try {
+    await wxLogin()
+    uni.reLaunch({ url: '/pages/index/index' })
+  } catch (err) {
+    uni.showToast({ title: err.message || '登录失败', icon: 'none' })
+  }
+}
+function goLocalList() { uni.navigateTo({ url: '/pages/login/local-list' }) }
+</script>
+```
+
+### 6.2 普通账号列表页
+- 进入页面时 `const accounts = getLocalAccounts()`。
+- 渲染 `accounts`（昵称、最近登录时间），并提供“新建普通账号”按钮。
+- 点击某个账号：
+  ```js
+  import { loginLocalAccount } from '@/utils/auth.js'
+  async function useAccount(item) {
+    await loginLocalAccount(item.user_id)
+    uni.reLaunch({ url: '/pages/index/index' })
+  }
+  ```
+- 长按弹出菜单：编辑昵称（直接更新缓存 + 云端 `user`）、删除（`removeLocalAccountCache` + 调用后端删除接口，若暂未实现可 TODO）。
+
+### 6.3 普通账号创建页
+- 表单：昵称输入 + 头像选择。
+- 提交：
+  ```js
+  import { createLocalAccount, getDeviceId } from '@/utils/auth.js'
+  async function submit() {
+    const nickname = form.nickname.trim() || '普通账号'
+    const avatar = form.avatar_url
+    await createLocalAccount({ nickname, avatar_url: avatar })
+    uni.reLaunch({ url: '/pages/index/index' })
+  }
+  ```
+- 创建成功后 `utils/local-account.js` 已缓存 `{ user_id, nickname, avatar_url }`，列表页直接可见。
+
+### 6.4 升级为微信账号页
+- 仅当当前登录态 `user.account_type === 'local'` 时展示“升级”按钮。
+- 点击触发：
+  ```js
+  import { upgradeLocalAccount } from '@/utils/auth.js'
+  async function upgrade(userId) {
+    try {
+      await upgradeLocalAccount(userId)
+      uni.showToast({ title: '升级成功' })
+      uni.reLaunch({ url: '/pages/index/index' })
+    } catch (err) {
+      uni.showModal({ title: '升级失败', content: err.message || '请稍后重试' })
+    }
+  }
+  ```
+- 成功后，前端可把该普通账号从本地列表中移除或标记“已升级（不可再登录）”。
+
+## 7. manifest 与后台配置
+1. **小程序后台**：
+   - 在“开发管理 → 开发设置”添加云函数 HTTP 域名；
+   - 配置合法 request 域名 `https://api.weixin.qq.com`（用于 `jscode2session`）。
+2. **云函数环境变量**：
+   - `WX_APPID`、`WX_SECRET` 写入 uniCloud 控制台或 HBuilderX 云函数运行配置。
+   - `UNICLOUD_TOKEN_SECRET`（可选）用于 `common/auth.js` 的 HMAC 秘钥。
+3. **manifest.json**：
+   - 勾选 `mp-weixin` 登录、用户信息权限；
+   - App 端在 `App权限-设备` 中启用“获取设备信息”（访问 `plus.device.uuid`）。
+
+## 8. 调试要点
+- 本地 HBuilderX 调试可通过“运行到小程序模拟器”快速验证 `wx.login`、`scene=mp-weixin`；App 端需真机运行以确保 `plus.device.uuid` 可用。
+- 若需要临时写死 `WX_APPID/WX_SECRET`，可在 `uniCloud/cloudfunctions/login/index.js` 顶部添加默认值，或通过 `.env` 设置。
+- 普通账号切换完全在本机完成：即便云端保存了数据，也必须携带 `device_id` 才能通过 `handleApp`。
+
+## 9. 下一步可扩展
+- 在 `user` 云函数中补充“修改昵称/头像”“删除普通账号”等接口，并与 `utils/local-account.js` 联动。
+- 根据业务需要拓展 `stats` 字段（如 `best_time`、`games_played`）。
+- 若需 App 端绑定微信，可在 `APP-PLUS` 分支中使用微信 SDK 获取 `code`，最终同样调用 `scene='upgrade'`。

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,9 @@
             "ios" : {
                 "dSYMs" : false
             },
+            "harmony" : {
+                "package" : "com.semi2025.super24.hm"
+            },
             "icons" : {
                 "android" : {
                     "hdpi" : "unpackage/res/icons/72x72.png",
@@ -55,15 +58,7 @@
                     }
                 }
             },
-            "sdkConfigs" : {
-                "ad" : {
-                    "ks" : {},
-                    "sigmob" : {},
-                    "zy" : {},
-                    "fl" : {},
-                    "jl" : {}
-                }
-            }
+            "sdkConfigs" : {}
         }
     },
     "mp-weixin" : {

--- a/pages.json
+++ b/pages.json
@@ -13,6 +13,28 @@
       }
     },
     {
+      "path": "pages/local-account/list",
+      "style": {
+        "navigationBarTitleText": "普通账号",
+        "app-plus": {
+          "titleNView": {
+            "autoBackButton": true
+          }
+        }
+      }
+    },
+    {
+      "path": "pages/local-account/create",
+      "style": {
+        "navigationBarTitleText": "创建普通账号",
+        "app-plus": {
+          "titleNView": {
+            "autoBackButton": true
+          }
+        }
+      }
+    },
+    {
       "path": "pages/index/index",
       "style": {
         "navigationBarTitleText": "无敌24点程序·观测",

--- a/pages/local-account/create.vue
+++ b/pages/local-account/create.vue
@@ -1,0 +1,130 @@
+<template>
+  <view class="create-page">
+    <AppNavBar title="创建普通账号" :show-back="true" />
+    <view class="form">
+      <view class="field">
+        <text class="label">昵称</text>
+        <input v-model="nickname" class="input" placeholder="请输入昵称" maxlength="16" />
+      </view>
+      <view class="field">
+        <text class="label">头像（可选）</text>
+        <view class="avatar-picker" @tap="chooseAvatar">
+          <image v-if="avatar" :src="avatar" mode="aspectFill" />
+          <text v-else>从相册选择</text>
+        </view>
+      </view>
+      <button class="primary" :loading="submitting" @tap="submit">创建并登录</button>
+      <view v-if="errMsg" class="error">{{ errMsg }}</view>
+    </view>
+  </view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import AppNavBar from '../../components/AppNavBar.vue'
+import { createLocalAccount } from '../../utils/auth.js'
+import { guessPlatformScene } from '../../utils/platform.js'
+
+const nickname = ref('')
+const avatar = ref('')
+const submitting = ref(false)
+const errMsg = ref('')
+
+function chooseAvatar() {
+  uni.chooseImage({
+    count: 1,
+    sizeType: ['compressed'],
+    success(res) {
+      const path = (res.tempFilePaths && res.tempFilePaths[0]) || ''
+      avatar.value = path
+    },
+  })
+}
+
+async function submit() {
+  if (submitting.value) return
+  const name = nickname.value.trim()
+  if (!name) {
+    errMsg.value = '请填写昵称'
+    return
+  }
+  submitting.value = true
+  errMsg.value = ''
+  try {
+    const uploadAvatar = avatar.value ? await uploadAvatarTemp(avatar.value) : ''
+    await createLocalAccount({ nickname: name, avatar_url: uploadAvatar, platform: guessPlatformScene() })
+    uni.showToast({ title: '创建成功', icon: 'success' })
+    uni.reLaunch({ url: '/pages/index/index' })
+  } catch (err) {
+    errMsg.value = err?.message || '创建失败'
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function uploadAvatarTemp(path) {
+  try {
+    const res = await uniCloud.uploadFile({ filePath: path, cloudPath: `avatars/${Date.now()}-${Math.random()}.png` })
+    return res.fileID || ''
+  } catch (err) {
+    console.warn('上传头像失败，转为本地路径', err)
+    return path
+  }
+}
+</script>
+
+<style scoped>
+.create-page {
+  min-height: 100vh;
+  padding: 24rpx;
+  background: #f8fafc;
+}
+.form {
+  margin-top: 32rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 32rpx;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+.label {
+  font-size: 28rpx;
+  color: #475569;
+}
+.input {
+  height: 88rpx;
+  border-radius: 16rpx;
+  border: 1px solid #cbd5f5;
+  padding: 0 24rpx;
+  background: #fff;
+}
+.avatar-picker {
+  height: 200rpx;
+  border: 1px dashed #94a3b8;
+  border-radius: 24rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+}
+.avatar-picker image {
+  width: 100%;
+  height: 100%;
+  border-radius: 24rpx;
+}
+.primary {
+  height: 96rpx;
+  border-radius: 20rpx;
+  background: linear-gradient(90deg, #4f46e5, #0ea5e9);
+  color: #fff;
+  border: none;
+  font-size: 32rpx;
+}
+.error {
+  color: #dc2626;
+  font-size: 26rpx;
+}
+</style>

--- a/pages/local-account/list.vue
+++ b/pages/local-account/list.vue
@@ -1,0 +1,172 @@
+<template>
+  <view class="local-page">
+    <AppNavBar title="本机普通账号" :show-back="true" />
+    <view class="section" v-if="accounts.length">
+      <view
+        v-for="item in accounts"
+        :key="item.user_id"
+        class="account-item card section"
+        @longpress="confirmDelete(item)"
+      >
+        <view class="info">
+          <image v-if="item.avatar_url" class="avatar" :src="item.avatar_url" mode="aspectFill" />
+          <view v-else class="avatar placeholder">{{ avatarText(item.nickname) }}</view>
+          <view class="meta">
+            <text class="name">{{ item.nickname }}</text>
+            <text class="date">上次：{{ formatDate(item.last_login_at) }}</text>
+          </view>
+        </view>
+        <button class="mini" :loading="loadingId === item.user_id" @tap="loginAccount(item)">登录</button>
+      </view>
+    </view>
+    <view v-else class="empty">暂无普通账号，请创建</view>
+
+    <button class="primary" @tap="toCreate">新建普通账号</button>
+
+    <view class="hint">长按账号可删除，仅删除本机记录。</view>
+    <view v-if="errMsg" class="error">{{ errMsg }}</view>
+  </view>
+</template>
+
+<script setup>
+import { ref, onShow } from 'vue'
+import AppNavBar from '../../components/AppNavBar.vue'
+import { getLocalAccounts, removeLocalAccount, setCurrentAccountId } from '../../utils/local-account.js'
+import { loginLocalAccount } from '../../utils/auth.js'
+import { guessPlatformScene } from '../../utils/platform.js'
+
+const accounts = ref([])
+const loadingId = ref('')
+const errMsg = ref('')
+
+onShow(() => {
+  load()
+})
+
+function load() {
+  accounts.value = getLocalAccounts()
+}
+
+async function loginAccount(item) {
+  if (!item || !item.user_id) return
+  errMsg.value = ''
+  loadingId.value = item.user_id
+  try {
+    await loginLocalAccount({ userId: item.user_id, platform: guessPlatformScene() })
+    setCurrentAccountId(item.user_id)
+    uni.showToast({ title: '登录成功', icon: 'success' })
+    uni.reLaunch({ url: '/pages/index/index' })
+  } catch (err) {
+    errMsg.value = err?.message || '登录失败'
+    uni.showToast({ title: errMsg.value, icon: 'none' })
+  } finally {
+    loadingId.value = ''
+  }
+}
+
+function toCreate() {
+  uni.navigateTo({ url: '/pages/local-account/create' })
+}
+
+function confirmDelete(item) {
+  uni.showModal({
+    title: '删除账号',
+    content: `确认删除“${item.nickname}”？此操作仅影响本机缓存`,
+    success: (res) => {
+      if (res.confirm) {
+        removeLocalAccount(item.user_id)
+        load()
+      }
+    },
+  })
+}
+
+function avatarText(name = '') {
+  return (String(name).trim() || 'U').slice(0, 1).toUpperCase()
+}
+
+function formatDate(ts) {
+  if (!ts) return '从未登录'
+  try {
+    const d = new Date(ts)
+    return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`
+  } catch (_) {
+    return '未知'
+  }
+}
+</script>
+
+<style scoped>
+.local-page {
+  min-height: 100vh;
+  padding: 24rpx;
+  background: #f8fafc;
+  box-sizing: border-box;
+}
+.section {
+  margin-top: 24rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+}
+.account-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24rpx;
+}
+.info {
+  display: flex;
+  align-items: center;
+  gap: 20rpx;
+}
+.avatar {
+  width: 96rpx;
+  height: 96rpx;
+  border-radius: 50%;
+  background: #cbd5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 36rpx;
+}
+.placeholder {
+  color: #0f172a;
+}
+.meta {
+  display: flex;
+  flex-direction: column;
+}
+.name {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+.date {
+  font-size: 26rpx;
+  color: #64748b;
+}
+.primary {
+  margin-top: 40rpx;
+  height: 96rpx;
+  border-radius: 20rpx;
+  background: linear-gradient(90deg, #4f46e5, #0ea5e9);
+  color: #fff;
+  border: none;
+  font-size: 32rpx;
+}
+.empty {
+  margin-top: 32rpx;
+  text-align: center;
+  color: #94a3b8;
+}
+.hint {
+  margin-top: 24rpx;
+  font-size: 26rpx;
+  color: #94a3b8;
+}
+.error {
+  margin-top: 20rpx;
+  color: #dc2626;
+  font-size: 26rpx;
+}
+</style>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -1,388 +1,136 @@
 <template>
-  <view
-    class="login-page"
-    :style="loginPageStyle"
-    @touchstart="edgeHandlers.handleTouchStart"
-    @touchmove="edgeHandlers.handleTouchMove"
-    @touchend="edgeHandlers.handleTouchEnd"
-    @touchcancel="edgeHandlers.handleTouchCancel"
-  >
-    <AppNavBar title="无敌24点程序·观测" :showBack="false" :with-safe-top="false" />
-
-    <!-- 主体 -->
-    <view class="login-body">
-      <view class="login-heading">
-        <text class="h1">选择玩家</text>
-      </view>
-
-      <!-- 错误状态 -->
-      <view v-if="errMsg" class="error-card card section">
-        <text class="err-title">数据异常</text>
-        <text class="err-text">{{ errMsg }}</text>
-        <button class="btn danger" @tap="resetData">重置数据</button>
-      </view>
-
-      <!-- 空状态 -->
-      <view v-else-if="(sortedUsers.length === 0)" class="empty-card card section">
-        <text class="empty-ill">🃏</text>
-        <text class="empty-text">还没有玩家，快创建一个吧！</text>
-        <button class="create-btn highlight" @tap="createUser">
-          <text class="create-plus">＋</text>
-          <text>新建玩家</text>
-        </button>
-      </view>
-
-      <!-- 用户列表 -->
-      <view v-else class="user-list">
-        <button class="user-item card section" v-for="u in sortedUsers" :key="u.id" @tap="choose(u)">
-          <image v-if="u.avatar" class="avatar-img" :src="u.avatar" mode="aspectFill" />
-          <view v-else class="avatar" :style="{ backgroundColor: u.color || colorFrom(u) }">{{ avatarText(u.name) }}</view>
-          <view class="user-col">
-            <view class="user-name">{{ u.name }}</view>
-            <view class="user-sub">最近：{{ lastPlayedText(u.lastPlayedAt) }}</view>
-          </view>
-          <text class="chev">›</text>
-        </button>
-        <button class="create-btn" @tap="createUser">
-          <text class="create-plus">＋</text>
-          <text>新建玩家</text>
-        </button>
-      </view>
+  <view class="login-method-page" :style="pageStyle">
+    <AppNavBar title="选择登录方式" :show-back="false" :with-safe-top="false" />
+    <view class="hero">
+      <text class="hero-emoji">🂡</text>
+      <text class="hero-title">同步你的 24 点战绩</text>
+      <text class="hero-sub">支持微信账号与本机普通账号</text>
     </view>
 
-    <!-- 底部区块：原“以游客登录”入口已移除 -->
-    <view
-      v-if="hintState.visible"
-      class="floating-hint-layer"
-      :class="{ interactive: hintState.interactive }"
-      @tap="hideHint"
-    >
-      <view class="floating-hint" @tap.stop>{{ hintState.text }}</view>
+    <view class="card">
+      <!-- 微信登录，仅小程序可见 -->
+      <!-- #ifdef MP-WEIXIN -->
+      <button class="action weixin" :loading="loading === 'wx'" @tap="handleWxLogin">
+        <text>使用微信账号登录</text>
+      </button>
+      <!-- #endif -->
+
+      <button class="action local" @tap="goLocalList">
+        <text>使用本机普通账号</text>
+      </button>
     </view>
+
+    <view class="tips">
+      <text>普通账号可离线使用，数据与当前设备绑定，可在“我的-升级”转为微信账号。</text>
+    </view>
+
+    <view v-if="errMsg" class="err">{{ errMsg }}</view>
   </view>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import { onBackPress, onShareAppMessage, onShareTimeline } from '@dcloudio/uni-app'
-import { ensureInit, getUsers, addUser, switchUser, resetAllData, touchLastPlayed } from '../../utils/store.js'
-import { saveAvatarForUser } from '../../utils/avatar.js'
-import { useFloatingHint } from '../../utils/hints.js'
-import { useEdgeExit } from '../../utils/edge-exit.js'
-import { exitApp } from '../../utils/navigation.js'
-import { useSafeArea } from '../../utils/useSafeArea.js'
-import { getSystemInfo } from '../../utils/system-compat.js'
+import { ref, computed } from 'vue'
 import AppNavBar from '../../components/AppNavBar.vue'
+import { loginWithWeixin } from '../../utils/auth.js'
+import { useSafeArea } from '../../utils/useSafeArea.js'
 
-const users = ref({ list: [], currentId: '' })
+const loading = ref('')
 const errMsg = ref('')
-
-const { hintState, showHint, hideHint } = useFloatingHint()
-const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitLoginPage() })
-
-let lastBackPress = 0
-onBackPress(() => {
-  const now = Date.now()
-  if (now - lastBackPress < 2000) {
-    exitLoginPage()
-  } else {
-    lastBackPress = now
-    try {
-      showHint('再按一次返回退出应用', { duration: 2000, interactive: false })
-    } catch (_) {
-      uni.showToast({ title: '再按一次退出应用', icon: 'none' })
-    }
-  }
-  return true
-})
 const { safeTop } = useSafeArea()
-const loginPageStyle = computed(() => ({ paddingTop: `${Math.max(0, safeTop.value || 0)}px` }))
+const pageStyle = computed(() => ({ paddingTop: `${Math.max(0, safeTop.value || 0)}px` }))
 
-onMounted(() => {
-  ensureInit();
-  safeLoad();
-  try { updateVHVar() } catch(_) {}
-  if (uni.onWindowResize) uni.onWindowResize(() => { try { updateVHVar() } catch(_) {} })
-})
-
-function updateVHVar(){
+async function handleWxLogin() {
+  if (loading.value) return
+  loading.value = 'wx'
+  errMsg.value = ''
   try {
-    const sys = getSystemInfo()
-    const h = sys.windowHeight || (typeof window !== 'undefined' ? window.innerHeight : 0) || 0
-    // #ifndef MP-WEIXIN
-    if (h && typeof document !== 'undefined' && document.documentElement && document.documentElement.style) {
-      document.documentElement.style.setProperty('--vh', (h * 0.01) + 'px')
+    const session = await loginWithWeixin('mp-weixin')
+    if (session?.user) {
+      uni.showToast({ title: '登录成功', icon: 'success' })
+      goHome()
     }
-    // #endif
-  } catch (_) { /* noop */ }
+  } catch (err) {
+    console.error(err)
+    errMsg.value = err?.message || '微信登录失败'
+  } finally {
+    loading.value = ''
+  }
 }
 
-function safeLoad(){
+function goLocalList() {
+  uni.navigateTo({ url: '/pages/local-account/list' })
+}
+
+function goHome() {
   try {
-    const u = getUsers()
-    // 简单校验结构
-    if (!u || !Array.isArray(u.list) || u.currentId === undefined) {
-      throw new Error('本地用户数据结构无效')
-    }
-    users.value = u
-  } catch (e) {
-    errMsg.value = (e && e.message) ? e.message : '本地存储损坏'
+    uni.reLaunch({ url: '/pages/index/index' })
+  } catch (err) {
+    uni.switchTab({ url: '/pages/index/index' })
   }
 }
-
-const sortedUsers = computed(() => {
-  // 过滤掉历史上可能遗留的“Guest/游客”记录，不在列表中展示
-  const list = (users.value.list || []).filter(u => String(u.name||'') !== 'Guest').slice()
-  list.sort((a,b) => (b.lastPlayedAt||0) - (a.lastPlayedAt||0) || (b.createdAt||0) - (a.createdAt||0))
-  return list
-})
-
-function refresh() { safeLoad() }
-function go(url){
-  // 登录流程进入首页：使用 reLaunch 清空栈，避免出现系统返回按钮
-  try { uni.reLaunch({ url }) }
-  catch(_) { try { uni.switchTab({ url }) } catch(_) {} }
-}
-// function goBack() { try { uni.navigateBack() } catch(e) { go('/pages/index/index') } }
-function choose(u) { switchUser(u.id); touchLastPlayed(u.id); go('/pages/index/index') }
-function createUser() {
-  uni.showModal({ title:'新建玩家', editable:true, placeholderText:'昵称（1-20字）', success(res){
-    if (!res.confirm) return
-    const name = String(res.content||'').trim()
-    if (!name || name.length < 1 || name.length > 20) { uni.showToast({ title:'请输入1-20字昵称', icon:'none' }); return }
-    const exists = (users.value.list||[]).some(x => String(x.name||'').toLowerCase() === name.toLowerCase())
-    if (exists) {
-      uni.showModal({ title:'提示', content:'已有同名玩家，是否继续创建？', success(r2){ if (r2.confirm) stepChooseAvatar(name); else createUser() } })
-    } else {
-      stepChooseAvatar(name)
-    }
-  }})
-}
-function stepChooseAvatar(name){
-  uni.showActionSheet({ itemList:['请选择头像方式','从相册选择','随机分配','跳过'], success(a){
-    const idx = a.tapIndex
-    if (idx === 1) {
-      uni.chooseImage({ count:1, sizeType:['compressed'], success(sel){
-        const path = (sel.tempFilePaths && sel.tempFilePaths[0]) || ''
-        const size = (sel.tempFiles && sel.tempFiles[0] && sel.tempFiles[0].size) || 0
-        finalizeCreate(name, path, size)
-      }, fail(){ finalizeCreate(name, '') } })
-    } else if (idx === 2) {
-      finalizeCreate(name, '') // 我们用随机背景色
-    } else if (idx === 3) {
-      finalizeCreate(name, '')
-    }
-    // idx === 0 就是点了“标题”，这里通常不处理
-  }, fail(){ finalizeCreate(name, '') } })
-}
-function finalizeCreate(name, avatar, size){
-  const id = addUser(name, '')
-  if (avatar) {
-    saveAvatarForUser(id, avatar, { size }).then(res => {
-      if (!res || !res.ok) {
-        try { uni.showToast({ title:'头像保存失败，请重试', icon:'none' }) } catch (_) {}
-      }
-    })
-  }
-  switchUser(id)
-  touchLastPlayed(id)
-  go('/pages/login/index')
-}
-function exitLoginPage(){
-  exitApp({
-    fallback: () => {
-      try { uni.navigateBack({ delta:1 }) }
-      catch (_) {
-        try { uni.reLaunch({ url:'/pages/index/index' }) }
-        catch (__) {}
-      }
-    },
-  })
-}
-function avatarText(name){
-  if (!name) return 'U'
-  const s = String(name).trim()
-  return s.length ? s[0].toUpperCase() : 'U'
-}
-function lastPlayedText(ts){
-  if (!ts) return '从未游玩'
-  try {
-    const d = new Date(ts)
-    const now = Date.now()
-    const dd = new Date()
-    const isToday = d.toDateString() === dd.toDateString()
-    const y = d.getFullYear(), m = (d.getMonth()+1).toString().padStart(2,'0'), day = d.getDate().toString().padStart(2,'0')
-    const hh = d.getHours().toString().padStart(2,'0'), mm = d.getMinutes().toString().padStart(2,'0')
-    if (isToday) return `今天 ${hh}:${mm}`
-    const yesterday = new Date(now - 86400000)
-    if (d.toDateString() === yesterday.toDateString()) return `昨天 ${hh}:${mm}`
-    return `${y}-${m}-${day} ${hh}:${mm}`
-  } catch(_) { return '时间未知' }
-}
-function colorFrom(u){
-  const base = String(u.id || u.name || '')
-  let hash = 0; for (let i=0;i<base.length;i++){ hash = (hash*33 + base.charCodeAt(i))>>>0 }
-  const palette = ['#e2e8f0','#fde68a','#bbf7d0','#bfdbfe','#fecaca','#f5d0fe','#c7d2fe']
-  return palette[hash % palette.length]
-}
-function resetData(){
-  uni.showModal({ title:'重置数据', content:'将清空本地所有数据，是否继续？', success(res){ if(res.confirm){ resetAllData(); errMsg.value=''; refresh() } } })
-}
-
-// 分享给好友
-onShareAppMessage(() => {
-  return {
-    title: '24点游戏小程序 - 挑战你的计算能力！',
-    path: '/pages/index/index',
-    imageUrl: '' // 使用系统默认截图或小程序logo
-  }
-})
-
-// 分享到朋友圈
-onShareTimeline(() => {
-  return {
-    title: '24点游戏小程序 - 挑战你的计算能力！',
-    query: '',
-    imageUrl: '' // 使用系统默认截图或小程序logo
-  }
-})
 </script>
 
 <style scoped>
- .login-page {
-  /* 视口高度填满，兼容移动端动态地址栏 */
-  min-height: 100dvh;
-  min-height: -webkit-fill-available;
-  background: #f1f5f9;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;  /* 防止整体滚动 */
+.login-method-page {
+  min-height: 100vh;
+  padding: 32rpx;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
   box-sizing: border-box;
-  padding: 0 24rpx;
-  padding-bottom: calc(24rpx + constant(safe-area-inset-bottom));
-  padding-bottom: calc(24rpx + env(safe-area-inset-bottom));
-  padding-top: constant(safe-area-inset-top);
-  padding-top: env(safe-area-inset-top);
 }
-body {
-  overflow: hidden;
-  height: 100vh;
+.hero {
+  margin-top: 40rpx;
+  text-align: center;
+  color: #0f172a;
 }
-/* .icon-btn{ width:64rpx; height:64rpx; border-radius:50%; background:#e5e7eb; display:flex; align-items:center; justify-content:center; border:none; } */
-.floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
-.floating-hint-layer.interactive{ pointer-events:auto }
-.floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
-.login-body {
-  flex: 1;  /* 占据剩余空间 */
-  padding: 10rpx 2.5rpx 0 2.5rpx;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;  /* 防止溢出 */
-  min-height: 0;  /* 允许收缩 */
-  /* 移除 height: 0; 这在iOS上可能导致内容不显示 */
+.hero-emoji {
+  font-size: 96rpx;
 }
-.login-heading { 
-  flex-shrink: 0;  /* 不收缩 */
-  text-align: center; 
-  margin: 0rpx 0 24rpx 0;
-  height: 80rpx;  /* 固定高度 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.hero-title {
+  margin-top: 16rpx;
+  font-size: 42rpx;
+  font-weight: 600;
+  display: block;
 }
-.h1{ font-size:56rpx; font-weight:900; color:#0e141b }
-.user-list {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 20rpx;
-  padding: 0 60rpx 20rpx 60rpx;  /* 改为padding，不用margin */
-  overflow-y: auto;
-  min-height: 0;
-  /* 移除 height: 0; 这在iOS上可能导致内容不显示 */
-  /* iOS兼容性：添加-webkit-前缀 */
-  -webkit-overflow-scrolling: touch;
+.hero-sub {
+  display: block;
+  margin-top: 8rpx;
+  font-size: 28rpx;
+  color: #475569;
 }
-/* 滚动条样式优化 */
-.user-list::-webkit-scrollbar {
-  width: 6rpx;
-}
-
-.user-list::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.user-list::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 3rpx;
-}
-
-.user-list::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
-}
-.user-item{ display:flex; align-items:center; padding:10rpx; height:100rpx;width:100%; border-radius:12rpx; border:2rpx solid #cfd8e3; background:#ffffff; box-shadow:0 2rpx 4rpx rgba(15,23,42,0.02) }
-.user-item:active{ transform:scale(0.98) }
-.avatar{ width:72rpx; height:72rpx; border-radius:50%; background:#e2e8f0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#0f172a; margin-right:20rpx }
-.avatar-img{ width:72rpx; height:72rpx; border-radius:50%; margin-right:20rpx; background:#e2e8f0 }
-.user-col{
-  flex:1;
-  display:flex;  /* 改为flex布局，在iOS上更稳定 */
-  flex-direction: column;
-  align-items:flex-start;
-  justify-content:center;
-  min-width:0;
-}
-.user-name {
-  font-size:34rpx;
-  color:#0f172a;
-  font-weight:700;
-  white-space:nowrap;               /* ✅ 不换行 */
-  overflow:hidden;
-  text-overflow:ellipsis;           /* ✅ 超长省略号 */
-  text-align:left;                    /* ✅ 明确指定左对齐 */
-  width: 100%;      /* 关键修复 */
-  max-width: 100%;  /* 双重保险 */
-  flex-shrink: 1;   /* iOS兼容：允许收缩 */
-}
-.user-sub {
-  font-size:20rpx;
-  color:#64748b;
-  white-space:nowrap;
-  text-align: right;       /* 文字靠右 */
-  flex-shrink: 0;   /* iOS兼容：不收缩 */
-  align-self: flex-end;     /* iOS兼容：右对齐 */
-}
-.chev{
-  flex:0 0 auto;          /* 不要挤压中间列 */
-  width: 40rpx;           /* 可选：固定宽度，视觉更稳 */
-  text-align:right;
-  color:#94a3b8; font-size:40rpx; font-weight:800; margin-left:12rpx;
-}
-.create-btn{ margin-top:20rpx; height:100rpx; border-radius:24rpx; background:#e2e8f0; color:#0f172a; font-size:32rpx; font-weight:800; border:none; display:flex; align-items:center; justify-content:center; gap:12rpx }
-.create-btn.highlight{ background:#145751; color:#fff }
-.create-plus{ font-size:36rpx }
-/* 底部区块相关样式已移除（guest 入口下线） */
-button{ -webkit-tap-highlight-color:rgba(0,0,0,0) }
-
-/* 空/错 视图 */
-.empty-card, .error-card {
-  flex: 1;  /* 占据可用空间 */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;  /* 垂直居中 */
-  gap: 16rpx;
-  padding: 40rpx 24rpx;
-  margin: 50rpx 100rpx;
-  border-radius: 24rpx;
+.card {
+  margin-top: 48rpx;
   background: #fff;
-  border: 2rpx solid #e5e7eb;
-  max-height: 100%;  /* 不超出容器 */
-  overflow-y: auto;  /* 如果内容过多也能滚动 */
+  border-radius: 24rpx;
+  box-shadow: 0 20rpx 60rpx rgba(15, 23, 42, 0.08);
+  padding: 32rpx 24rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
 }
-.empty-ill{ font-size:88rpx }
-.empty-text{ color:#6b7280 }
-.err-title{ font-weight:800; color:#b91c1c }
-.err-text{ color:#6b7280; text-align:center }
-.btn.danger{ background:#ef4444; color:#fff; border:none; padding:20rpx 28rpx; border-radius:14rpx }
+.action {
+  height: 96rpx;
+  border-radius: 18rpx;
+  border: none;
+  font-size: 32rpx;
+  color: #0f172a;
+}
+.action.weixin {
+  background: #06c160;
+  color: #fff;
+}
+.action.local {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+.tips {
+  margin-top: 32rpx;
+  font-size: 26rpx;
+  color: #475569;
+  line-height: 1.5;
+}
+.err {
+  margin-top: 20rpx;
+  color: #dc2626;
+  font-size: 26rpx;
+}
 </style>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -6,6 +6,30 @@
         @touchend="edgeHandlers.handleTouchEnd"
         @touchcancel="edgeHandlers.handleTouchCancel">
     <AppNavBar title="用户管理" :show-back="true" :with-safe-top="false" :back-to-index="true" />
+    <view class="cloud-card card section">
+      <view class="cloud-header">
+        <text class="cloud-title">当前账号</text>
+        <text class="cloud-type" v-if="sessionUser">{{ sessionUser.account_type === 'weixin' ? '微信账号' : '普通账号' }}</text>
+      </view>
+      <view v-if="sessionUser" class="cloud-body">
+        <text class="cloud-name">{{ sessionUser.nickname || '未命名账号' }}</text>
+        <text class="cloud-id">ID: {{ sessionUser._id }}</text>
+        <view class="cloud-ops">
+          <!-- #ifdef MP-WEIXIN -->
+          <button
+            v-if="sessionUser.account_type === 'local'"
+            class="btn highlight"
+            :loading="upgradeLoading"
+            @tap="upgradeAccount"
+          >升级为微信账号</button>
+          <!-- #endif -->
+          <text v-if="sessionUser.account_type === 'weixin'" class="cloud-tip">已绑定微信，可跨设备登录</text>
+        </view>
+        <view v-if="upgradeErr" class="cloud-err">{{ upgradeErr }}</view>
+      </view>
+      <view v-else class="cloud-empty">暂未登录云端账号，请在登录页选择登录方式。</view>
+    </view>
+
     <view class="row" style="gap:12rpx; align-items:center;">
       <input v-model="newName" placeholder="新用户名称" class="input" />
       <button class="btn btn-primary" @tap="create">添加</button>
@@ -47,9 +71,13 @@ import { saveAvatarForUser, removeAvatarForUser, consumeAvatarRestoreNotice } fr
 import { navigateToHome } from '../../utils/navigation.js'
 import { useSafeArea, rpxToPx } from '../../utils/useSafeArea.js'
 import { getCachedUsersState, setCachedUsersState, scheduleTabWarmup } from '../../utils/tab-cache.js'
+import { getSession, upgradeLocalAccount } from '../../utils/auth.js'
 
 const users = ref({ list: [], currentId: '' })
 const newName = ref('')
+const sessionUser = ref(null)
+const upgradeLoading = ref(false)
+const upgradeErr = ref('')
 
 const { hintState, showHint, hideHint } = useFloatingHint()
 const edgeHandlers = useEdgeExit({ showHint, onExit: () => exitPage() })
@@ -89,6 +117,11 @@ function loadUsers() {
   setCachedUsersState(data)
 }
 
+function refreshSessionState() {
+  const session = getSession()
+  sessionUser.value = session ? session.user : null
+}
+
 // 过滤掉游客账号（名称为 Guest 的历史记录）
 const visibleUsers = computed(() => (users.value.list || []).filter(u => String(u.name||'') !== 'Guest'))
 
@@ -96,14 +129,34 @@ onMounted(() => {
   try { uni.hideTabBar && uni.hideTabBar() } catch (_) {}
   ensureInit()
   loadUsers()
+  refreshSessionState()
 })
 
 onShow(() => {
   loadUsers()
+  refreshSessionState()
   if (consumeAvatarRestoreNotice()) {
     showHint('头像文件丢失，已为你恢复为默认头像', 2000)
   }
 })
+
+async function upgradeAccount() {
+  if (!sessionUser.value || sessionUser.value.account_type !== 'local') {
+    upgradeErr.value = '当前账号无需升级'
+    return
+  }
+  upgradeLoading.value = true
+  upgradeErr.value = ''
+  try {
+    await upgradeLocalAccount({ userId: sessionUser.value._id, platform: 'mp-weixin' })
+    refreshSessionState()
+    uni.showToast({ title: '升级成功', icon: 'success' })
+  } catch (err) {
+    upgradeErr.value = err?.message || '升级失败'
+  } finally {
+    upgradeLoading.value = false
+  }
+}
 
 function create(){
   addUser(newName.value.trim()||undefined)
@@ -226,5 +279,16 @@ onShareTimeline(() => {
 .floating-hint-layer{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index:999 }
 .floating-hint-layer.interactive{ pointer-events:auto }
 .floating-hint{ max-width:70%; background:rgba(15,23,42,0.86); color:#fff; padding:24rpx 36rpx; border-radius:24rpx; text-align:center; font-size:30rpx; box-shadow:0 20rpx 48rpx rgba(15,23,42,0.25); backdrop-filter:blur(12px) }
+.cloud-card{ margin-bottom:24rpx; display:flex; flex-direction:column; gap:12rpx }
+.cloud-header{ display:flex; justify-content:space-between; align-items:center }
+.cloud-title{ font-size:32rpx; font-weight:600 }
+.cloud-type{ font-size:26rpx; color:#64748b }
+.cloud-body{ display:flex; flex-direction:column; gap:8rpx }
+.cloud-name{ font-size:30rpx; font-weight:600 }
+.cloud-id{ font-size:24rpx; color:#94a3b8 }
+.cloud-ops{ margin-top:8rpx; display:flex; flex-wrap:wrap; gap:12rpx; align-items:center }
+.cloud-tip{ font-size:24rpx; color:#10b981 }
+.cloud-err{ color:#dc2626; font-size:24rpx }
+.cloud-empty{ color:#94a3b8; font-size:26rpx }
 </style>
 

--- a/uniCloud-aliyun/cloudfunctions/common/auth/index.js
+++ b/uniCloud-aliyun/cloudfunctions/common/auth/index.js
@@ -1,0 +1,67 @@
+const crypto = require('crypto')
+
+const TOKEN_SECRET = process.env.TF24_TOKEN_SECRET || 'TF24_DEV_SECRET_CHANGE_ME'
+const TOKEN_TTL = 60 * 60 * 24 * 15 // 15 days
+
+function base64UrlEncode(input) {
+  const buff = Buffer.isBuffer(input) ? input : Buffer.from(input)
+  return buff.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+
+function base64UrlDecode(str = '') {
+  str = str.replace(/-/g, '+').replace(/_/g, '/')
+  while (str.length % 4) {
+    str += '='
+  }
+  return Buffer.from(str, 'base64').toString('utf8')
+}
+
+function sign(data) {
+  return crypto.createHmac('sha256', TOKEN_SECRET).update(data).digest('base64url')
+}
+
+function createToken(user, options = {}) {
+  if (!user || !user._id) {
+    throw new Error('无法为匿名用户生成 token')
+  }
+  const header = { alg: 'HS256', typ: 'JWT' }
+  const now = Math.floor(Date.now() / 1000)
+  const payload = {
+    uid: user._id,
+    account_type: user.account_type,
+    device_id: user.device_id || '',
+    openid: user.openid || '',
+    iat: now,
+    exp: now + (options.ttl || TOKEN_TTL),
+  }
+  const headerEncoded = base64UrlEncode(JSON.stringify(header))
+  const payloadEncoded = base64UrlEncode(JSON.stringify(payload))
+  const signature = sign(`${headerEncoded}.${payloadEncoded}`)
+  return `${headerEncoded}.${payloadEncoded}.${signature}`
+}
+
+function verifyToken(token) {
+  if (!token || typeof token !== 'string') {
+    throw new Error('token 缺失')
+  }
+  const parts = token.split('.')
+  if (parts.length !== 3) {
+    throw new Error('token 结构无效')
+  }
+  const [headerEncoded, payloadEncoded, signature] = parts
+  const expected = sign(`${headerEncoded}.${payloadEncoded}`)
+  if (signature !== expected) {
+    throw new Error('token 签名无效')
+  }
+  const payload = JSON.parse(base64UrlDecode(payloadEncoded))
+  const now = Math.floor(Date.now() / 1000)
+  if (payload.exp && payload.exp < now) {
+    throw new Error('token 已过期')
+  }
+  return payload
+}
+
+module.exports = {
+  createToken,
+  verifyToken,
+}

--- a/uniCloud-aliyun/cloudfunctions/login/index.js
+++ b/uniCloud-aliyun/cloudfunctions/login/index.js
@@ -1,0 +1,313 @@
+'use strict'
+
+const crypto = require('crypto')
+const auth = require('../common/auth/index.js')
+const db = uniCloud.database()
+const users = db.collection('user')
+
+const ENV_WX_APPID = process.env.WX_APPID || ''
+const ENV_WX_SECRET = process.env.WX_SECRET || ''
+let configCenter
+try {
+  if (typeof uniCloud.getConfigCenter === 'function') {
+    configCenter = uniCloud.getConfigCenter()
+  }
+} catch (err) {
+  console.warn('读取 uni-config-center 失败，可忽略（将使用环境变量）', err && err.message)
+}
+let cachedWxConfig = null
+
+exports.main = async (event, context) => {
+  const scene = event && event.scene
+  try {
+    let result
+    if (scene === 'mp-weixin') {
+      result = await handleMpWeixin(event)
+    } else if (scene === 'app') {
+      result = await handleApp(event)
+    } else if (scene === 'upgrade') {
+      result = await handleUpgrade(event)
+    } else {
+      throw new Error('scene 不受支持')
+    }
+    return { success: true, ...result }
+  } catch (err) {
+    return {
+      success: false,
+      errCode: err.errCode || -1,
+      errMsg: err.message || '登录失败',
+    }
+  }
+}
+
+async function handleMpWeixin(event = {}) {
+  const { code, platform } = event
+  if (!code) {
+    throw new Error('code 缺失')
+  }
+  const session = await fetchWeixinSession(code)
+  if (!session || !session.openid) {
+    throw new Error('获取 openid 失败')
+  }
+  const openid = session.openid
+  const unionid = session.unionid || ''
+
+  const userRes = await users.where({ openid }).limit(1).get()
+  let userDoc = userRes.data && userRes.data[0]
+  const now = Date.now()
+  if (!userDoc) {
+    const newUser = {
+      _id: generateUserId(),
+      account_type: 'weixin',
+      openid,
+      unionid,
+      device_id: '',
+      nickname: '',
+      avatar_url: '',
+      platforms: appendPlatform([], platform || 'mp-weixin'),
+      created_at: now,
+      last_login_at: now,
+      stats: defaultStats(),
+    }
+    await users.add(newUser)
+    userDoc = newUser
+  } else {
+    await users.doc(userDoc._id).update({
+      last_login_at: now,
+      unionid: unionid || userDoc.unionid || '',
+      platforms: appendPlatform(userDoc.platforms, platform || 'mp-weixin'),
+    })
+    userDoc = { ...userDoc, last_login_at: now, unionid: unionid || userDoc.unionid || '', platforms: appendPlatform(userDoc.platforms, platform || 'mp-weixin') }
+  }
+
+  const token = auth.createToken(userDoc)
+  return { token, user: sanitizeUser(userDoc) }
+}
+
+async function handleApp(event = {}) {
+  const { deviceId, user_id, platform, extra = {}, create } = event
+  if (!deviceId) {
+    throw new Error('deviceId 缺失')
+  }
+  const now = Date.now()
+  if (user_id) {
+    const snap = await users.doc(user_id).get()
+    const userDoc = snap.data && snap.data[0]
+    if (!userDoc) {
+      throw new Error('账号不存在')
+    }
+    if (userDoc.account_type !== 'local') {
+      throw new Error('仅普通账号可使用此入口登录')
+    }
+    if (!userDoc.device_id || userDoc.device_id !== deviceId) {
+      throw new Error('此账号仅限创建它的设备使用')
+    }
+    await users.doc(userDoc._id).update({
+      last_login_at: now,
+      platforms: appendPlatform(userDoc.platforms, platform || 'app-unknown'),
+    })
+    const merged = { ...userDoc, last_login_at: now, platforms: appendPlatform(userDoc.platforms, platform || 'app-unknown') }
+    const token = auth.createToken(merged)
+    return { token, user: sanitizeUser(merged) }
+  }
+
+  if (!create) {
+    throw new Error('缺少 user_id，且未声明创建账号')
+  }
+  const nickname = (extra.nickname && String(extra.nickname).trim()) || '本机玩家'
+  const avatar_url = extra.avatar_url || ''
+  const newUser = {
+    _id: generateUserId(),
+    account_type: 'local',
+    openid: '',
+    unionid: '',
+    device_id: deviceId,
+    nickname,
+    avatar_url,
+    platforms: appendPlatform([], platform || 'app-unknown'),
+    created_at: now,
+    last_login_at: now,
+    stats: defaultStats(),
+  }
+  await users.add(newUser)
+  const token = auth.createToken(newUser)
+  return { token, user: sanitizeUser(newUser) }
+}
+
+async function handleUpgrade(event = {}) {
+  const { code, user_id, platform } = event
+  if (!code || !user_id) {
+    throw new Error('参数缺失')
+  }
+  const session = await fetchWeixinSession(code)
+  if (!session || !session.openid) {
+    throw new Error('获取微信身份失败')
+  }
+  const openid = session.openid
+  const unionid = session.unionid || ''
+  const now = Date.now()
+
+  const localSnap = await users.doc(user_id).get()
+  const localUser = localSnap.data && localSnap.data[0]
+  if (!localUser) {
+    throw new Error('待升级账号不存在')
+  }
+  if (localUser.account_type !== 'local') {
+    throw new Error('仅普通账号支持升级')
+  }
+
+  const wxSnap = await users.where({ openid }).limit(1).get()
+  const wxUser = wxSnap.data && wxSnap.data[0]
+  if (!wxUser) {
+    await users.doc(localUser._id).update({
+      account_type: 'weixin',
+      openid,
+      unionid,
+      platforms: appendPlatform(localUser.platforms, platform || 'mp-weixin'),
+      last_login_at: now,
+    })
+    const upgraded = {
+      ...localUser,
+      account_type: 'weixin',
+      openid,
+      unionid,
+      platforms: appendPlatform(localUser.platforms, platform || 'mp-weixin'),
+      last_login_at: now,
+    }
+    const token = auth.createToken(upgraded)
+    return { token, user: sanitizeUser(upgraded) }
+  }
+
+  const mergedStats = mergeStats(wxUser.stats, localUser.stats)
+  await users.doc(wxUser._id).update({
+    stats: mergedStats,
+    last_login_at: now,
+    platforms: appendPlatform(wxUser.platforms, platform || 'mp-weixin'),
+  })
+  await users.doc(localUser._id).update({ merged_to: wxUser._id, merged_at: now })
+  const mergedUser = {
+    ...wxUser,
+    stats: mergedStats,
+    last_login_at: now,
+    platforms: appendPlatform(wxUser.platforms, platform || 'mp-weixin'),
+  }
+  const token = auth.createToken(mergedUser)
+  return { token, user: sanitizeUser(mergedUser) }
+}
+
+async function fetchWeixinSession(code) {
+  const { appid, secret } = resolveWeixinConfig()
+  const url = 'https://api.weixin.qq.com/sns/jscode2session'
+  const res = await uniCloud.httpclient.request(url, {
+    method: 'GET',
+    data: {
+      appid,
+      secret,
+      js_code: code,
+      grant_type: 'authorization_code',
+    },
+    dataType: 'json',
+    timeout: 5000,
+  })
+  const data = res.data || {}
+  if (data.errcode) {
+    const err = new Error(data.errmsg || 'jscode2session 失败')
+    err.errCode = data.errcode
+    throw err
+  }
+  return data
+}
+
+function resolveWeixinConfig() {
+  if (cachedWxConfig) {
+    return cachedWxConfig
+  }
+  const envCred = pickWxCredential({ appid: ENV_WX_APPID, secret: ENV_WX_SECRET })
+  if (envCred && !envCred.appid.includes('YOUR_WECHAT')) {
+    cachedWxConfig = envCred
+    return cachedWxConfig
+  }
+  const candidates = []
+  if (configCenter && typeof configCenter.config === 'function') {
+    candidates.push(configCenter.config('wx-login'))
+    candidates.push(configCenter.config('weixin'))
+    candidates.push(configCenter.config('uni-id'))
+  }
+  if (configCenter && typeof configCenter.require === 'function') {
+    try { candidates.push(configCenter.require('wx-login')) } catch (_) {}
+    try { candidates.push(configCenter.require('weixin')) } catch (_) {}
+    try { candidates.push(configCenter.require('uni-id')) } catch (_) {}
+  }
+  for (const candidate of candidates) {
+    const cred = extractWxConfig(candidate)
+    if (cred) {
+      cachedWxConfig = cred
+      return cachedWxConfig
+    }
+  }
+  throw new Error('请在环境变量或 uni-config-center 中配置 WX_APPID/WX_SECRET')
+}
+
+function extractWxConfig(candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    return null
+  }
+  if (candidate['mp-weixin']) {
+    const cred = pickWxCredential(candidate['mp-weixin'])
+    if (cred) return cred
+  }
+  if (candidate.mp && candidate.mp.weixin) {
+    const cred = pickWxCredential(candidate.mp.weixin)
+    if (cred) return cred
+  }
+  if (candidate.weixin) {
+    const cred = pickWxCredential(candidate.weixin)
+    if (cred) return cred
+  }
+  return pickWxCredential(candidate)
+}
+
+function pickWxCredential(obj) {
+  if (!obj || typeof obj !== 'object') return null
+  const appid = obj.appid || obj.appId || ''
+  const secret = obj.secret || obj.appsecret || obj.appSecret || ''
+  if (appid && secret) {
+    return { appid, secret }
+  }
+  return null
+}
+
+function sanitizeUser(user) {
+  if (!user) return null
+  const clone = { ...user }
+  delete clone.openid
+  delete clone.device_id
+  delete clone.unionid
+  return clone
+}
+
+function appendPlatform(list = [], platform) {
+  const arr = Array.isArray(list) ? list.slice() : []
+  if (platform && !arr.includes(platform)) {
+    arr.push(platform)
+  }
+  return arr
+}
+
+function defaultStats() {
+  return { score: 0, coins: 0 }
+}
+
+function mergeStats(a = {}, b = {}) {
+  return {
+    score: Math.max(Number(a.score) || 0, Number(b.score) || 0),
+    coins: (Number(a.coins) || 0) + (Number(b.coins) || 0),
+  }
+}
+
+function generateUserId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return 'u_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 10)
+}

--- a/uniCloud-aliyun/cloudfunctions/login/package.json
+++ b/uniCloud-aliyun/cloudfunctions/login/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "login",
+  "dependencies": {}
+}

--- a/uniCloud-aliyun/database/user.schema.json
+++ b/uniCloud-aliyun/database/user.schema.json
@@ -1,0 +1,32 @@
+{
+  "bsonType": "object",
+  "required": ["_id", "account_type", "created_at", "stats"],
+  "properties": {
+    "_id": { "bsonType": "string", "description": "user_id" },
+    "account_type": { "enum": ["weixin", "local"] },
+    "openid": { "bsonType": "string" },
+    "unionid": { "bsonType": "string" },
+    "device_id": { "bsonType": "string" },
+    "nickname": { "bsonType": "string" },
+    "avatar_url": { "bsonType": "string" },
+    "platforms": {
+      "bsonType": "array",
+      "items": { "bsonType": "string" }
+    },
+    "created_at": { "bsonType": "long" },
+    "last_login_at": { "bsonType": "long" },
+    "stats": {
+      "bsonType": "object",
+      "properties": {
+        "score": { "bsonType": "int" },
+        "coins": { "bsonType": "int" }
+      }
+    },
+    "merged_to": { "bsonType": "string" },
+    "merged_at": { "bsonType": "long" }
+  },
+  "indexes": [
+    { "name": "openid_unique", "unique": true, "fields": { "openid": 1 }, "partialFilterExpression": { "openid": { "$exists": true } } },
+    { "name": "device_id_index", "fields": { "device_id": 1 } }
+  ]
+}

--- a/uniCloud/cloudfunctions/common/auth.js
+++ b/uniCloud/cloudfunctions/common/auth.js
@@ -1,0 +1,50 @@
+'use strict'
+const crypto = require('crypto')
+
+const DEFAULT_SECRET = 'CHANGE_ME_TO_A_LONG_RANDOM_SECRET'
+const TOKEN_TTL = 1000 * 60 * 60 * 24 * 30 // 30 days
+
+function getSecret() {
+  return process.env.UNICLOUD_TOKEN_SECRET || DEFAULT_SECRET
+}
+
+function encode(data) {
+  return Buffer.from(JSON.stringify(data)).toString('base64url')
+}
+
+function decode(str) {
+  try {
+    return JSON.parse(Buffer.from(str, 'base64url').toString('utf8'))
+  } catch (err) {
+    return null
+  }
+}
+
+function sign(payloadB64) {
+  return crypto.createHmac('sha256', getSecret()).update(payloadB64).digest('base64url')
+}
+
+function createToken(user) {
+  const payload = {
+    uid: user._id || user.id,
+    issued_at: Date.now(),
+    expired_at: Date.now() + TOKEN_TTL
+  }
+  const payloadB64 = encode(payload)
+  const signature = sign(payloadB64)
+  return `${payloadB64}.${signature}`
+}
+
+function verifyToken(token = '') {
+  if (!token || typeof token !== 'string') return null
+  const [payloadB64, signature] = token.split('.')
+  if (!payloadB64 || !signature) return null
+  const expected = sign(payloadB64)
+  if (expected !== signature) return null
+  const payload = decode(payloadB64)
+  if (!payload || !payload.uid) return null
+  if (payload.expired_at && payload.expired_at < Date.now()) return null
+  return { uid: payload.uid }
+}
+
+module.exports = { createToken, verifyToken }

--- a/uniCloud/cloudfunctions/game/index.js
+++ b/uniCloud/cloudfunctions/game/index.js
@@ -1,0 +1,51 @@
+'use strict'
+const auth = require('../common/auth.js')
+const db = uniCloud.database()
+const recordCollection = db.collection('game_record')
+
+function pickToken(event = {}) {
+  if (event.token) return event.token
+  const authHeader = event.headers?.Authorization || event.headers?.authorization
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7)
+  }
+  return ''
+}
+
+async function ensureLogin(event) {
+  const token = pickToken(event)
+  const verified = auth.verifyToken(token)
+  if (!verified) {
+    throw new Error('NOT_LOGIN')
+  }
+  return verified.uid
+}
+
+module.exports = async (event = {}, context) => {
+  const action = event.action || 'listRecords'
+  try {
+    const uid = await ensureLogin(event)
+    if (action === 'listRecords') {
+      const { limit = 20 } = event.data || {}
+      const res = await recordCollection.where({ uid }).orderBy('created_at', 'desc').limit(limit).get()
+      return { code: 0, list: res.data }
+    }
+    if (action === 'saveRecord') {
+      const { puzzle = [], success = false, time_spent = 0 } = event.data || {}
+      await recordCollection.add({
+        uid,
+        puzzle,
+        success,
+        time_spent,
+        created_at: Date.now()
+      })
+      return { code: 0 }
+    }
+    return { code: 404, message: 'UNKNOWN_ACTION' }
+  } catch (err) {
+    if (err.message === 'NOT_LOGIN') {
+      return { code: 401, message: 'NOT_LOGIN' }
+    }
+    return { code: 500, message: err.message }
+  }
+}

--- a/uniCloud/cloudfunctions/game/package.json
+++ b/uniCloud/cloudfunctions/game/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "game",
+  "dependencies": {}
+}

--- a/uniCloud/cloudfunctions/login/index.js
+++ b/uniCloud/cloudfunctions/login/index.js
@@ -1,0 +1,235 @@
+'use strict'
+const auth = require('../common/auth.js')
+const db = uniCloud.database()
+const userCollection = db.collection('user')
+
+const WX_APPID = process.env.WX_APPID || ''
+const WX_SECRET = process.env.WX_SECRET || ''
+
+function now() {
+  return Date.now()
+}
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value.slice() : []
+}
+
+function ensurePlatforms(current = [], platform) {
+  const list = ensureArray(current)
+  if (platform && !list.includes(platform)) {
+    list.push(platform)
+  }
+  return list
+}
+
+function normalizeStats(stats = {}) {
+  return {
+    score: Number.isFinite(Number(stats.score)) ? Number(stats.score) : 0,
+    coins: Number.isFinite(Number(stats.coins)) ? Number(stats.coins) : 0
+  }
+}
+
+function mergeStats(targetStats = {}, incomingStats = {}) {
+  const base = normalizeStats(targetStats)
+  const incoming = normalizeStats(incomingStats)
+  return {
+    score: Math.max(base.score, incoming.score),
+    coins: base.coins + incoming.coins
+  }
+}
+
+async function fetchWeixinSession(code) {
+  if (!code) {
+    throw new Error('缺少微信登录 code')
+  }
+  if (!WX_APPID || !WX_SECRET) {
+    throw new Error('未配置微信小程序密钥')
+  }
+  const resp = await uniCloud.httpclient.request('https://api.weixin.qq.com/sns/jscode2session', {
+    method: 'GET',
+    dataType: 'json',
+    data: {
+      appid: WX_APPID,
+      secret: WX_SECRET,
+      js_code: code,
+      grant_type: 'authorization_code'
+    }
+  })
+  if (!resp.data || resp.data.errcode) {
+    throw new Error(resp.data?.errmsg || '微信登录失败')
+  }
+  return resp.data
+}
+
+function sanitizeUser(user) {
+  if (!user) return null
+  const cloned = { ...user }
+  delete cloned.password
+  delete cloned.device_id
+  delete cloned.merged_to
+  delete cloned.unionid // 可根据需要返回，此处默认隐藏
+  return cloned
+}
+
+async function handleMpWeixin(scenePayload = {}) {
+  const { code, platform = 'mp-weixin' } = scenePayload
+  const session = await fetchWeixinSession(code)
+  const openid = session.openid
+  const unionid = session.unionid || ''
+  const nowTs = now()
+  let userDoc = await userCollection.where({ openid }).limit(1).get()
+  let user = userDoc.data[0]
+  if (!user) {
+    const newUser = {
+      account_type: 'weixin',
+      openid,
+      unionid,
+      device_id: '',
+      nickname: '',
+      avatar_url: '',
+      platforms: ensurePlatforms([], platform),
+      created_at: nowTs,
+      last_login_at: nowTs,
+      stats: normalizeStats(),
+      gender: 0
+    }
+    const res = await userCollection.add(newUser)
+    user = { _id: res.id, ...newUser }
+  } else {
+    const platforms = ensurePlatforms(user.platforms, platform)
+    user.platforms = platforms
+    user.last_login_at = nowTs
+    await userCollection.doc(user._id).update({
+      platforms,
+      last_login_at: nowTs,
+      unionid
+    })
+  }
+  const token = auth.createToken(user)
+  return { token, user: sanitizeUser(user) }
+}
+
+async function handleApp(scenePayload = {}) {
+  const {
+    deviceId,
+    user_id,
+    platform = 'app-plus',
+    extra = {}
+  } = scenePayload
+  if (!deviceId) {
+    throw new Error('缺少 deviceId，无法校验普通账号')
+  }
+  const nowTs = now()
+  if (user_id) {
+    const userDoc = await userCollection.doc(user_id).get()
+    const user = userDoc.data && userDoc.data[0]
+    if (!user) {
+      throw new Error('普通账号不存在或已被删除')
+    }
+    if (user.account_type !== 'local') {
+      throw new Error('该账号不是普通账号，无法通过本机登录')
+    }
+    if (user.device_id && user.device_id !== deviceId) {
+      throw new Error('此账号仅限创建它的设备使用')
+    }
+    const platforms = ensurePlatforms(user.platforms, platform)
+    user.platforms = platforms
+    user.last_login_at = nowTs
+    await userCollection.doc(user._id).update({
+      last_login_at: nowTs,
+      platforms
+    })
+    const token = auth.createToken(user)
+    return { token, user: sanitizeUser(user) }
+  }
+  if (!extra || !extra.create) {
+    throw new Error('缺少 user_id，且未指定创建普通账号')
+  }
+  const nickname = String(extra.nickname || '普通账号').slice(0, 32)
+  const newUser = {
+    account_type: 'local',
+    openid: '',
+    unionid: '',
+    device_id: deviceId,
+    nickname,
+    avatar_url: extra.avatar_url || '',
+    platforms: ensurePlatforms([], platform),
+    created_at: nowTs,
+    last_login_at: nowTs,
+    stats: normalizeStats(extra.stats),
+    gender: extra.gender || 0
+  }
+  const res = await userCollection.add(newUser)
+  const user = { _id: res.id, ...newUser }
+  const token = auth.createToken(user)
+  return { token, user: sanitizeUser(user) }
+}
+
+async function handleUpgrade(scenePayload = {}) {
+  const { code, user_id, platform = 'mp-weixin', deviceId } = scenePayload
+  if (!code) {
+    throw new Error('缺少微信登录 code')
+  }
+  if (!user_id) {
+    throw new Error('缺少需要升级的 user_id')
+  }
+  const session = await fetchWeixinSession(code)
+  const openid = session.openid
+  const unionid = session.unionid || ''
+  const localDoc = await userCollection.doc(user_id).get()
+  const localUser = localDoc.data && localDoc.data[0]
+  if (!localUser) {
+    throw new Error('待升级的普通账号不存在')
+  }
+  if (localUser.account_type !== 'local') {
+    throw new Error('该账号已是微信账号或不可升级')
+  }
+  if (deviceId && localUser.device_id && localUser.device_id !== deviceId) {
+    throw new Error('此账号仅限创建它的设备升级')
+  }
+  const nowTs = now()
+  const wxDoc = await userCollection.where({ openid }).limit(1).get()
+  let user
+  if (!wxDoc.data.length) {
+    const platforms = ensurePlatforms(localUser.platforms, platform)
+    const updated = {
+      account_type: 'weixin',
+      openid,
+      unionid,
+      last_login_at: nowTs,
+      platforms
+    }
+    await userCollection.doc(localUser._id).update(updated)
+    user = { ...localUser, ...updated }
+  } else {
+    const wxUser = wxDoc.data[0]
+    const platforms = ensurePlatforms(wxUser.platforms, platform)
+    const mergedStats = mergeStats(wxUser.stats, localUser.stats)
+    await userCollection.doc(wxUser._id).update({
+      stats: mergedStats,
+      last_login_at: nowTs,
+      platforms
+    })
+    await userCollection.doc(localUser._id).update({
+      merged_to: wxUser._id,
+      merged_at: nowTs
+    })
+    user = { ...wxUser, stats: mergedStats, platforms, last_login_at: nowTs }
+  }
+  const token = auth.createToken(user)
+  return { token, user: sanitizeUser(user) }
+}
+
+module.exports = async (event = {}, context) => {
+  const { scene, platform, code, deviceId, user_id, extra } = event
+  if (scene === 'mp-weixin') {
+    return await handleMpWeixin({ code, platform })
+  }
+  if (scene === 'app') {
+    return await handleApp({ deviceId, user_id, platform, extra })
+  }
+  if (scene === 'upgrade') {
+    return await handleUpgrade({ code, user_id, platform, deviceId })
+  }
+  throw new Error('不支持的登录场景')
+}

--- a/uniCloud/cloudfunctions/login/package.json
+++ b/uniCloud/cloudfunctions/login/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "login",
+  "dependencies": {}
+}

--- a/uniCloud/cloudfunctions/user/index.js
+++ b/uniCloud/cloudfunctions/user/index.js
@@ -1,0 +1,61 @@
+'use strict'
+const auth = require('../common/auth.js')
+const db = uniCloud.database()
+const userCollection = db.collection('user')
+
+function pickToken(event = {}) {
+  if (event.token) return event.token
+  const authHeader = event.headers?.Authorization || event.headers?.authorization
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7)
+  }
+  return ''
+}
+
+async function getUser(uid) {
+  if (!uid) return null
+  const res = await userCollection.doc(uid).get()
+  return res.data && res.data[0]
+}
+
+function sanitize(user) {
+  if (!user) return null
+  const clone = { ...user }
+  delete clone.password
+  return clone
+}
+
+module.exports = async (event = {}, context) => {
+  const token = pickToken(event)
+  const verified = auth.verifyToken(token)
+  if (!verified) {
+    return { code: 401, message: 'NOT_LOGIN' }
+  }
+  const action = event.action || 'getProfile'
+  const uid = verified.uid
+  if (action === 'getProfile') {
+    const user = await getUser(uid)
+    return { code: 0, user: sanitize(user) }
+  }
+  if (action === 'updateProfile') {
+    const { nickname = '', avatar_url = '', gender = 0 } = event.data || {}
+    await userCollection.doc(uid).update({
+      nickname,
+      avatar_url,
+      gender,
+      updated_at: Date.now()
+    })
+    const user = await getUser(uid)
+    return { code: 0, user: sanitize(user) }
+  }
+  if (action === 'setPhone') {
+    const { phone } = event.data || {}
+    if (!phone) {
+      return { code: 400, message: 'PHONE_REQUIRED' }
+    }
+    await userCollection.doc(uid).update({ phone, updated_at: Date.now() })
+    const user = await getUser(uid)
+    return { code: 0, user: sanitize(user) }
+  }
+  return { code: 404, message: 'UNKNOWN_ACTION' }
+}

--- a/uniCloud/cloudfunctions/user/package.json
+++ b/uniCloud/cloudfunctions/user/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "user",
+  "dependencies": {}
+}

--- a/uniCloud/database/game_record.schema.json
+++ b/uniCloud/database/game_record.schema.json
@@ -1,0 +1,21 @@
+{
+  "bsonType": "object",
+  "required": ["uid", "success"],
+  "properties": {
+    "_id": { "bsonType": "objectId" },
+    "uid": { "bsonType": "string" },
+    "puzzle": {
+      "bsonType": "array",
+      "items": { "bsonType": ["int", "string"] }
+    },
+    "success": { "bsonType": "bool" },
+    "time_spent": { "bsonType": "int" },
+    "created_at": { "bsonType": "long" }
+  },
+  "indexes": [
+    {
+      "name": "idx_uid_created",
+      "fields": { "uid": 1, "created_at": -1 }
+    }
+  ]
+}

--- a/uniCloud/database/settings.schema.json
+++ b/uniCloud/database/settings.schema.json
@@ -1,0 +1,18 @@
+{
+  "bsonType": "object",
+  "required": ["key"],
+  "properties": {
+    "_id": { "bsonType": "objectId" },
+    "key": { "bsonType": "string" },
+    "value": {},
+    "description": { "bsonType": "string" },
+    "updated_at": { "bsonType": "long" }
+  },
+  "indexes": [
+    {
+      "name": "idx_key",
+      "unique": true,
+      "fields": { "key": 1 }
+    }
+  ]
+}

--- a/uniCloud/database/user.schema.json
+++ b/uniCloud/database/user.schema.json
@@ -1,0 +1,45 @@
+{
+  "bsonType": "object",
+  "required": ["account_type", "nickname"],
+  "properties": {
+    "_id": { "bsonType": "string", "description": "user_id，全局唯一" },
+    "account_type": { "enum": ["weixin", "local"], "description": "账号类型" },
+    "openid": { "bsonType": "string", "description": "mp-weixin openid" },
+    "unionid": { "bsonType": "string" },
+    "device_id": { "bsonType": "string", "description": "普通账号绑定的设备ID" },
+    "nickname": { "bsonType": "string" },
+    "avatar_url": { "bsonType": "string" },
+    "gender": { "bsonType": "int" },
+    "platforms": {
+      "bsonType": "array",
+      "items": { "bsonType": "string" }
+    },
+    "stats": {
+      "bsonType": "object",
+      "properties": {
+        "score": { "bsonType": "int" },
+        "coins": { "bsonType": "int" }
+      }
+    },
+    "created_at": { "bsonType": "long" },
+    "last_login_at": { "bsonType": "long" },
+    "updated_at": { "bsonType": "long" },
+    "merged_to": { "bsonType": "string" },
+    "merged_at": { "bsonType": "long" }
+  },
+  "indexes": [
+    {
+      "name": "idx_openid",
+      "unique": true,
+      "fields": { "openid": 1 }
+    },
+    {
+      "name": "idx_device",
+      "fields": { "device_id": 1 }
+    },
+    {
+      "name": "idx_account_type",
+      "fields": { "account_type": 1 }
+    }
+  ]
+}

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,0 +1,116 @@
+import { ensureDeviceId, upsertLocalAccount, setCurrentAccountId, getCurrentAccountId, syncAccountFromRemote } from './local-account.js'
+
+const SESSION_KEY = 'tf24_session_v1'
+
+export function getSession() {
+  try {
+    return uni.getStorageSync(SESSION_KEY) || null
+  } catch (_) {
+    return null
+  }
+}
+
+export function setSession(payload) {
+  try {
+    uni.setStorageSync(SESSION_KEY, payload || null)
+  } catch (err) {
+    console.warn('写入 session 失败', err)
+  }
+}
+
+export function clearSession() {
+  try {
+    uni.removeStorageSync(SESSION_KEY)
+  } catch (_) {}
+}
+
+export async function loginWithWeixin(platform = 'mp-weixin') {
+  // #ifndef MP-WEIXIN
+  throw new Error('当前平台不支持微信登录')
+  // #endif
+  // #ifdef MP-WEIXIN
+  const { code } = await uni.login({ provider: 'weixin' }).catch(err => {
+    throw new Error(err?.errMsg || 'wx.login 失败')
+  })
+  const res = await callLogin({ scene: 'mp-weixin', code, platform })
+  applySessionResponse(res)
+  return res
+  // #endif
+}
+
+export async function loginLocalAccount({ userId, platform = 'app-android' } = {}) {
+  const deviceId = ensureDeviceId()
+  if (!userId) {
+    userId = getCurrentAccountId()
+  }
+  if (!userId) {
+    throw new Error('缺少 user_id')
+  }
+  const res = await callLogin({ scene: 'app', deviceId, user_id: userId, platform })
+  applySessionResponse(res)
+  setCurrentAccountId(userId)
+  syncAccountFromRemote(res.user)
+  return res
+}
+
+export async function createLocalAccount({ nickname, avatar_url = '', platform = 'app-android' } = {}) {
+  const deviceId = ensureDeviceId()
+  const res = await callLogin({
+    scene: 'app',
+    deviceId,
+    platform,
+    create: true,
+    extra: { nickname, avatar_url },
+  })
+  applySessionResponse(res)
+  upsertLocalAccount({
+    user_id: res.user._id,
+    nickname: res.user.nickname || nickname,
+    avatar_url: res.user.avatar_url || avatar_url,
+    created_at: res.user.created_at,
+    last_login_at: res.user.last_login_at,
+  })
+  setCurrentAccountId(res.user._id)
+  return res
+}
+
+export async function upgradeLocalAccount({ userId, platform = 'mp-weixin' }) {
+  if (!userId) {
+    throw new Error('缺少 user_id')
+  }
+  // #ifndef MP-WEIXIN
+  throw new Error('仅在微信小程序内支持升级')
+  // #endif
+  // #ifdef MP-WEIXIN
+  const { code } = await uni.login({ provider: 'weixin' }).catch(err => {
+    throw new Error(err?.errMsg || 'wx.login 失败')
+  })
+  const res = await callLogin({ scene: 'upgrade', code, user_id: userId, platform })
+  applySessionResponse(res)
+  syncAccountFromRemote(res.user)
+  return res
+  // #endif
+}
+
+async function callLogin(data) {
+  const resp = await uniCloud.callFunction({ name: 'login', data })
+  if (!resp || !resp.result) {
+    throw new Error('云函数无返回')
+  }
+  if (!resp.result.success) {
+    throw new Error(resp.result.errMsg || '登录失败')
+  }
+  if (!resp.result.token || !resp.result.user) {
+    throw new Error('云端返回数据不完整')
+  }
+  return resp.result
+}
+
+function applySessionResponse(res) {
+  const session = {
+    token: res.token,
+    user: res.user,
+    timestamp: Date.now(),
+  }
+  setSession(session)
+}

--- a/utils/local-account.js
+++ b/utils/local-account.js
@@ -1,0 +1,100 @@
+const ACCOUNT_KEY = 'tf24_local_accounts_v1'
+const DEVICE_KEY = 'tf24_device_id_v1'
+const CURRENT_KEY = 'tf24_current_account_id'
+
+export function getLocalAccounts() {
+  try {
+    const stored = uni.getStorageSync(ACCOUNT_KEY)
+    if (Array.isArray(stored)) return stored
+  } catch (err) {
+    console.warn('读取本地账号失败', err)
+  }
+  return []
+}
+
+export function saveLocalAccounts(list) {
+  try {
+    uni.setStorageSync(ACCOUNT_KEY, list || [])
+  } catch (err) {
+    console.warn('保存本地账号失败', err)
+  }
+}
+
+export function upsertLocalAccount(account) {
+  if (!account || !account.user_id) return
+  const list = getLocalAccounts()
+  const idx = list.findIndex(item => item.user_id === account.user_id)
+  const payload = normalizeAccount(account)
+  if (idx > -1) {
+    list[idx] = { ...list[idx], ...payload }
+  } else {
+    list.push(payload)
+  }
+  saveLocalAccounts(list)
+  return list
+}
+
+export function removeLocalAccount(userId) {
+  const list = getLocalAccounts().filter(item => item.user_id !== userId)
+  saveLocalAccounts(list)
+  return list
+}
+
+export function findLocalAccount(userId) {
+  return getLocalAccounts().find(item => item.user_id === userId)
+}
+
+export function setCurrentAccountId(userId) {
+  try {
+    uni.setStorageSync(CURRENT_KEY, userId || '')
+  } catch (_) {}
+}
+
+export function getCurrentAccountId() {
+  try {
+    return uni.getStorageSync(CURRENT_KEY) || ''
+  } catch (_) {
+    return ''
+  }
+}
+
+export function ensureDeviceId() {
+  let id = ''
+  try {
+    id = uni.getStorageSync(DEVICE_KEY)
+  } catch (_) {}
+  if (id) return id
+  // #ifdef APP-PLUS
+  try {
+    id = plus.device.uuid
+  } catch (err) {
+    console.warn('获取 plus.device.uuid 失败', err)
+  }
+  // #endif
+  if (!id) {
+    id = `dev_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  }
+  try { uni.setStorageSync(DEVICE_KEY, id) } catch (_) {}
+  return id
+}
+
+export function syncAccountFromRemote(user) {
+  if (!user || !user._id) return
+  upsertLocalAccount({
+    user_id: user._id,
+    nickname: user.nickname || '本机玩家',
+    avatar_url: user.avatar_url || '',
+    created_at: user.created_at || Date.now(),
+    last_login_at: user.last_login_at || Date.now(),
+  })
+}
+
+function normalizeAccount(account) {
+  return {
+    user_id: account.user_id || account._id,
+    nickname: account.nickname || '本机玩家',
+    avatar_url: account.avatar_url || '',
+    created_at: account.created_at || Date.now(),
+    last_login_at: account.last_login_at || Date.now(),
+  }
+}

--- a/utils/platform.js
+++ b/utils/platform.js
@@ -1,0 +1,16 @@
+export function guessPlatformScene() {
+  let platform = 'app-unknown'
+  // #ifdef MP-WEIXIN
+  platform = 'mp-weixin'
+  // #endif
+  // #ifdef APP-PLUS
+  platform = 'app-android'
+  // #endif
+  // #ifdef APP-IOS
+  platform = 'app-ios'
+  // #endif
+  // #ifdef APP-HARMONY
+  platform = 'app-harmony'
+  // #endif
+  return platform
+}

--- a/utils/system-compat.js
+++ b/utils/system-compat.js
@@ -1,0 +1,97 @@
+const PLATFORM_KEYS = ['platform', 'osName', 'system', 'uniPlatform']
+
+let cachedInfo = null
+
+function detectFromNavigator() {
+  if (typeof navigator === 'undefined') return {}
+  const ua = navigator.userAgent || ''
+  const lowerUA = ua.toLowerCase()
+  const isIOS = /iphone|ipad|ipod/.test(lowerUA)
+  const isAndroid = /android/.test(lowerUA)
+  const system = isIOS ? 'iOS' : (isAndroid ? 'Android' : '')
+  return {
+    platform: system ? system.toLowerCase() : 'web',
+    system,
+    brand: navigator.vendor || '',
+    model: '',
+    windowWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
+    windowHeight: typeof window !== 'undefined' ? window.innerHeight : undefined,
+  }
+}
+
+export function getSystemInfo(force = false) {
+  if (!force && cachedInfo) return cachedInfo
+
+  let info = {}
+  try {
+    if (typeof uni !== 'undefined' && typeof uni.getSystemInfoSync === 'function') {
+      info = uni.getSystemInfoSync() || {}
+    } else if (typeof wx !== 'undefined' && typeof wx.getSystemInfoSync === 'function') {
+      info = wx.getSystemInfoSync() || {}
+    } else if (typeof plus !== 'undefined' && plus.os) {
+      info = {
+        platform: (plus.os.name || '').toLowerCase(),
+        system: plus.os.version,
+        brand: plus.device?.vendor,
+        model: plus.device?.model,
+        windowWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
+        windowHeight: typeof window !== 'undefined' ? window.innerHeight : undefined,
+      }
+    } else {
+      info = detectFromNavigator()
+    }
+  } catch (err) {
+    console.warn('getSystemInfo failed, fallback to navigator:', err)
+    info = detectFromNavigator()
+  }
+
+  cachedInfo = info || {}
+  return cachedInfo
+}
+
+export function refreshSystemInfo() {
+  cachedInfo = null
+  return getSystemInfo(true)
+}
+
+function platformString() {
+  const info = getSystemInfo() || {}
+  const raw = PLATFORM_KEYS.map((key) => String(info?.[key] || '')).find((val) => val)
+  return (raw || '').toLowerCase()
+}
+
+export function isIOS() {
+  const platform = platformString()
+  if (platform.includes('ios')) return true
+  const sys = String(getSystemInfo()?.system || '').toLowerCase()
+  return sys.includes('ios')
+}
+
+export function isAndroid() {
+  const platform = platformString()
+  if (platform.includes('android')) return true
+  const sys = String(getSystemInfo()?.system || '').toLowerCase()
+  return sys.includes('android')
+}
+
+export function isHarmonyOS() {
+  const info = getSystemInfo() || {}
+  const platform = platformString()
+  if (platform.includes('harmony')) return true
+  const sys = String(info?.osName || info?.system || '').toLowerCase()
+  return sys.includes('harmony') || sys.includes('hongmeng')
+}
+
+export function supportsSafeAreaInsets() {
+  const info = getSystemInfo() || {}
+  return Boolean(info.safeArea || info.safeAreaInsets)
+}
+
+export default {
+  getSystemInfo,
+  refreshSystemInfo,
+  isIOS,
+  isAndroid,
+  isHarmonyOS,
+  supportsSafeAreaInsets,
+}


### PR DESCRIPTION
## Summary
- update the login cloud function so jscode2session credentials are loaded from either WX_APPID/WX_SECRET env vars or uni-config-center with helpful fallbacks
- expand the account-system notes to describe the config sourcing, device_id persistence, and why local-account deletes are local-only

## Testing
- not run (uni-app project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185fcd0b148323be0f9e16ac300cff)